### PR TITLE
fix output when only partial data is returned

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -15,8 +15,8 @@ function* run (context, heroku) {
     return {
       addons: heroku.apps(app).addons().listByApp(),
       app: heroku.request({path: appUrl}),
-      dynos: heroku.apps(app).dynos().list(),
-      collaborators: heroku.apps(app).collaborators().list()
+      dynos: heroku.apps(app).dynos().list().catch(() => []),
+      collaborators: heroku.apps(app).collaborators().list().catch(() => []),
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "co": "4.6.0",
     "filesize": "3.1.3",
-    "heroku-cli-util": "5.4.6",
+    "heroku-cli-util": "5.4.10",
     "lodash": "3.10.1",
     "string": "3.3.1"
   },


### PR DESCRIPTION
for deleted apps, the call to dynos and collaborators will fail. This is fine, the data should just not be displayed for those.