### PR TITLE
Show dyno count in ps

### DIFF
--- a/commands/ps/index.js
+++ b/commands/ps/index.js
@@ -63,7 +63,7 @@ function printDynos (dynos) {
     return dynosByCommand;
   }, {});
   _.forEach(dynosByCommand, function (dynos, key) {
-    cli.styledHeader(key);
+    cli.styledHeader(`${key} (${dynos.length})`);
     dynos = dynos.sort((a, b) => getProcessNum(a) - getProcessNum(b));
     for (let dyno of dynos) cli.log(dyno);
     cli.log();

--- a/test/commands/ps/index.js
+++ b/test/commands/ps/index.js
@@ -18,7 +18,7 @@ describe('ps', function() {
         {command: 'npm start', size: 'Free', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up'},
       ]);
     return cmd.run({app: 'myapp', flags: {}})
-    .then(() => expect(cli.stdout).to.equal(`=== web (Free): npm start
+    .then(() => expect(cli.stdout).to.equal(`=== web (Free): npm start (1)
 web.1: up ${hourAgoStr} (~ 1h ago)
 
 `))


### PR DESCRIPTION
`heroku ps` shows a list of all running dynos by type.
But when there's a lot of them, it can be hard to know how many there are. Especially if they are one-off.