### PR TITLE
Allow the url to pass through unmodified to add

### DIFF
--- a/lib/buildpacks.js
+++ b/lib/buildpacks.js
@@ -17,19 +17,14 @@ function BuildpackCommand(context, heroku, command, action) {
     this.index = null;
   }
 
-  this.url    = context.args && context.args.url && this.mapBuildpackUrl(context.args.url);
+  this.url    = context.args && context.args.url;
   this.action = action;
   this.command = command;
 }
 
-BuildpackCommand.prototype.mapBuildpackUrl = function(url) {
-  return url.replace(/^urn:buildpack:/, '').replace(/^https:\/\/codon-buildpacks\.s3\.amazonaws\.com\/buildpacks\/heroku\/(.*)\.tgz$/, 'heroku/$1');
-};
-
 BuildpackCommand.prototype.mapBuildpackResponse = function(buildpacks) {
-  let buildpackCommand = this;
   return buildpacks.map(function(bp) {
-    bp.buildpack.url = buildpackCommand.mapBuildpackUrl(bp.buildpack.url);
+    bp.buildpack.url = bp.buildpack.url.replace(/^urn:buildpack:/, '');
     return bp;
   });
 };
@@ -91,7 +86,8 @@ BuildpackCommand.prototype.findIndex = function(buildpacks) {
 
 BuildpackCommand.prototype.findUrl = function findUrl(buildpacks) {
   let url = this.url;
-  return _.findIndex(buildpacks, function(b) { return b.buildpack.url === url; });
+  let mappedUrl = this.url.replace(/^urn:buildpack:/, '').replace(/^https:\/\/codon-buildpacks\.s3\.amazonaws\.com\/buildpacks\/heroku\/(.*)\.tgz$/, 'heroku/$1');
+  return _.findIndex(buildpacks, function(b) { return b.buildpack.url === url || b.buildpack.url === mappedUrl; });
 };
 
 BuildpackCommand.prototype.display = function (buildpacks, indent) {

--- a/test/commands/buildpacks/add.js
+++ b/test/commands/buildpacks/add.js
@@ -38,12 +38,12 @@ Run git push heroku master to create a new release using this buildpack.
       });
     });
 
-    it('# maps buildpack urns', function() {
+    it('# does not map buildpack urns', function() {
       stub_get();
 
       let mock = nock('https://api.heroku.com')
       .put('/apps/example/buildpack-installations', {
-        updates: [{buildpack: 'heroku/ruby'}]
+        updates: [{buildpack: 'urn:buildpack:heroku/ruby'}]
       })
       .reply(200, [{buildpack: {url: 'urn:buildpack:heroku/ruby', name: 'heroku/ruby'}, ordinal: 0}]);
 
@@ -144,6 +144,16 @@ Run git push heroku master to create a new release using these buildpacks.
         app: 'example', args: {url: 'http://github.com/foobar/foobar'},
       })).then(function() {
         expect(unwrap(cli.stderr)).to.equal(' ▸    The buildpack http://github.com/foobar/foobar is already set on your app.\n');
+      });
+    });
+
+    it('# errors out on unmapped codon urls', function() {
+      stub_get('https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/jvm-common.tgz');
+
+      return assert_exit(1, buildpacks.run({
+        app: 'example', args: {url: 'https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/jvm-common.tgz'},
+      })).then(function() {
+        expect(unwrap(cli.stderr)).to.equal(' ▸    The buildpack https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/jvm-common.tgz is already set on your app.\n');
       });
     });
 

--- a/test/commands/buildpacks/index.js
+++ b/test/commands/buildpacks/index.js
@@ -35,7 +35,7 @@ heroku/ruby
     });
   });
 
-  it('# maps buildpack s3 to names', function() {
+  it('# does not map buildpack s3 to names', function() {
     stub_get('https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz');
 
     return buildpacks.run({app: 'example'})
@@ -43,7 +43,7 @@ heroku/ruby
       expect(cli.stderr).to.equal('');
       expect(cli.stdout).to.equal(
 `=== example Buildpack URL
-heroku/ruby
+https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
 `);
     });
   });


### PR DESCRIPTION
* We were translating the add url like the following

  https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
  => heroku/ruby

This causes problems when heroku/ruby is not mapped in the API.
We are now just passing the URL straight through and letting API
do the translation for us.