### PR TITLE
Correct a typo in the app:create help text

### DIFF
--- a/commands/apps/create.js
+++ b/commands/apps/create.js
@@ -97,7 +97,7 @@ let cmd = {
     {name: 'addons', hasValue: true, description: 'comma-delimited list of addons to install'},
     {name: 'buildpack', char: 'b', hasValue: true, description: 'buildpack url to use for this app'},
     {name: 'no-remote', char: 'n', description: 'do not create a git remote'},
-    {name: 'remote', char: 'r', hasValue: true, description: 'the git remtoe to create, default "heroku"'},
+    {name: 'remote', char: 'r', hasValue: true, description: 'the git remote to create, default "heroku"'},
     {name: 'stack', char: 's', hasValue: true, description: 'the stack to create the app on'},
     {name: 'space', hasValue: true, description: 'the private space to create the app in'},
     {name: 'region', hasValue: true, description: 'specify region for the app to run in'},


### PR DESCRIPTION
Happened to spot this whilst referring to the output of `heroku apps:create --help`.

Whilst I was here I scanned the help text for the other commands using a spell-checker, but didn't find any other obvious mistakes.