### PR TITLE
Update release status wording

### DIFF
--- a/commands/releases/status_helper.js
+++ b/commands/releases/status_helper.js
@@ -3,6 +3,7 @@
 module.exports = function (s) {
   switch (s) {
     case 'success':
+    case 'succeeded':
     case null:
       return {
         color: 'green'
@@ -13,6 +14,7 @@ module.exports = function (s) {
         content: 'release command executing'
       }
     case 'failure':
+    case 'failed':
       return {
         color: 'red',
         content: 'release command failed'

--- a/test/commands/releases/index.js
+++ b/test/commands/releases/index.js
@@ -13,7 +13,7 @@ describe('releases', () => {
     {
       'created_at': '2015-11-18T01:37:41Z',
       'description': 'Set foo config vars',
-      'status': 'success',
+      'status': 'succeeded',
       'id': '5efa3510-e8df-4db0-a176-83ff8ad91eb5',
       'slug': {
         'id': '37994c83-39a3-4cbf-b318-8f9dc648f701'
@@ -28,7 +28,7 @@ describe('releases', () => {
     {
       'created_at': '2015-11-18T01:36:38Z',
       'description': 'Remove AWS_SECRET_ACCESS_KEY config vars',
-      'status': 'failure',
+      'status': 'failed',
       'id': '7be47426-2c1b-4e4d-b6e5-77c79169aa41',
       'slug': {
         'id': '37994c83-39a3-4cbf-b318-8f9dc648f701'
@@ -76,7 +76,7 @@ describe('releases', () => {
     {
       'created_at': '2015-11-18T01:37:41Z',
       'description': 'Set foo config vars',
-      'status': 'success',
+      'status': 'succeeded',
       'id': '5efa3510-e8df-4db0-a176-83ff8ad91eb5',
       'slug': {
         'id': '37994c83-39a3-4cbf-b318-8f9dc648f701'

--- a/test/commands/releases/info.js
+++ b/test/commands/releases/info.js
@@ -139,6 +139,29 @@ When:    ${d.toISOString()}
       .then(() => api.done())
   })
 
+  it('shows a failed (failure) release info', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/myapp/releases')
+      .reply(200, [{version: 10}])
+      .get('/apps/myapp/releases/10')
+      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
+      .reply(200, {
+        description: 'something changed',
+        status: 'failure',
+        user: { email: 'foo@foo.com' },
+        created_at: d,
+        version: 10
+      })
+    return cmd.run({app: 'myapp', flags: {}, args: {}})
+      .then(() => expect(cli.stdout, 'to equal', `=== Release v10
+By:      foo@foo.com
+Change:  something changed (release command failed)
+When:    ${d.toISOString()}
+`))
+      .then(() => expect(cli.stderr, 'to be empty'))
+      .then(() => api.done())
+  })
+
   it('shows a pending release info', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')

--- a/test/commands/releases/info.js
+++ b/test/commands/releases/info.js
@@ -124,7 +124,7 @@ FOO: foo
       .matchHeader('accept', 'application/vnd.heroku+json; version=3')
       .reply(200, {
         description: 'something changed',
-        status: 'failure',
+        status: 'failed',
         user: { email: 'foo@foo.com' },
         created_at: d,
         version: 10


### PR DESCRIPTION
The current status wording is inconsistent with the one used for builds and app setups.
This allows both wordings so we can change it in API. I will remove the old one later on.