### PR TITLE
Remove success/failure case

### DIFF
--- a/commands/releases/status_helper.js
+++ b/commands/releases/status_helper.js
@@ -2,7 +2,6 @@
 
 module.exports = function (s) {
   switch (s) {
-    case 'success':
     case 'succeeded':
     case null:
       return {
@@ -13,7 +12,6 @@ module.exports = function (s) {
         color: 'yellow',
         content: 'release command executing'
       }
-    case 'failure':
     case 'failed':
       return {
         color: 'red',

--- a/test/commands/releases/info.js
+++ b/test/commands/releases/info.js
@@ -139,29 +139,6 @@ When:    ${d.toISOString()}
       .then(() => api.done())
   })
 
-  it('shows a failed (failure) release info', function () {
-    let api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-      .get('/apps/myapp/releases/10')
-      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
-      .reply(200, {
-        description: 'something changed',
-        status: 'failure',
-        user: { email: 'foo@foo.com' },
-        created_at: d,
-        version: 10
-      })
-    return cmd.run({app: 'myapp', flags: {}, args: {}})
-      .then(() => expect(cli.stdout, 'to equal', `=== Release v10
-By:      foo@foo.com
-Change:  something changed (release command failed)
-When:    ${d.toISOString()}
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
-  })
-
   it('shows a pending release info', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')


### PR DESCRIPTION
API now handles all releases with succeeded/failed.