### PR TITLE
Add filter for private and common runtimes

### DIFF
--- a/commands/regions/index.js
+++ b/commands/regions/index.js
@@ -8,9 +8,9 @@ function * run (context, heroku) {
 
   let regions = yield heroku.get('/regions')
   if (context.flags.private) {
-    regions = regions.filter((region) => { return region.private_capable })
+    regions = regions.filter(region => region.private_capable)
   } else if (context.flags.common) {
-    regions = regions.filter((region) => { return !region.private_capable })
+    regions = regions.filter(region => !region.private_capable)
   }
   regions = sortBy(regions, ['private_capable', 'name'])
 

--- a/commands/regions/index.js
+++ b/commands/regions/index.js
@@ -5,13 +5,12 @@ const co = require('co')
 
 function * run (context, heroku) {
   const sortBy = require('lodash.sortby')
-  const filter = require('lodash.filter')
 
   let regions = yield heroku.get('/regions')
   if (context.flags.private) {
-    regions = filter(regions, { 'private_capable': true })
+    regions = regions.filter((region) => { return region.private_capable })
   } else if (context.flags.common) {
-    regions = filter(regions, { 'private_capable': false })
+    regions = regions.filter((region) => { return !region.private_capable })
   }
   regions = sortBy(regions, ['private_capable', 'name'])
 

--- a/commands/regions/index.js
+++ b/commands/regions/index.js
@@ -5,9 +5,16 @@ const co = require('co')
 
 function * run (context, heroku) {
   const sortBy = require('lodash.sortby')
+  const filter = require('lodash.filter')
 
   let regions = yield heroku.get('/regions')
+  if (context.flags.private) {
+    regions = filter(regions, { 'private_capable': true })
+  } else if (context.flags.common) {
+    regions = filter(regions, { 'private_capable': false })
+  }
   regions = sortBy(regions, ['private_capable', 'name'])
+
   if (context.flags.json) {
     cli.log(JSON.stringify(regions, 0, 2))
   } else {
@@ -26,7 +33,9 @@ module.exports = {
   description: 'list available regions for deployment',
   needsAuth: true,
   flags: [
-    {name: 'json', description: 'output in json format'}
+    {name: 'json', description: 'output in json format'},
+    {name: 'private', description: 'show regions for private spaces'},
+    {name: 'common', description: 'show regions for common runtime'}
   ],
   run: cli.command(co.wrap(run))
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lodash": "4.12.0",
     "lodash.compact": "3.0.1",
     "lodash.countby": "4.4.0",
+    "lodash.filter": "^4.5.0",
     "lodash.findindex": "4.4.0",
     "lodash.flatten": "4.2.0",
     "lodash.foreach": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lodash": "4.12.0",
     "lodash.compact": "3.0.1",
     "lodash.countby": "4.4.0",
-    "lodash.filter": "^4.5.0",
     "lodash.findindex": "4.4.0",
     "lodash.flatten": "4.2.0",
     "lodash.foreach": "4.3.0",

--- a/test/commands/regions/index.js
+++ b/test/commands/regions/index.js
@@ -13,16 +13,48 @@ describe('regions', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/regions')
       .reply(200, [
-        {name: 'eu', description: 'Europe'},
-        {name: 'us', description: 'United States'},
+        {name: 'eu', description: 'Europe', private_capable: false},
+        {name: 'us', description: 'United States', private_capable: false},
         {name: 'oregon', description: 'Oregon, United States', private_capable: true}
       ])
     return cmd.run({flags: {}})
       .then(() => expect(cli.stdout).to.equal(`ID      Location               Runtime
 ──────  ─────────────────────  ──────────────
-oregon  Oregon, United States  Private Spaces
 eu      Europe                 Common Runtime
 us      United States          Common Runtime
+oregon  Oregon, United States  Private Spaces
+`))
+      .then(() => api.done())
+  })
+
+  it('filters private regions', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/regions')
+      .reply(200, [
+        {name: 'eu', description: 'Europe', private_capable: false},
+        {name: 'us', description: 'United States', private_capable: false},
+        {name: 'oregon', description: 'Oregon, United States', private_capable: true}
+      ])
+    return cmd.run({flags: { private: true }})
+      .then(() => expect(cli.stdout).to.equal(`ID      Location               Runtime
+──────  ─────────────────────  ──────────────
+oregon  Oregon, United States  Private Spaces
+`))
+      .then(() => api.done())
+  })
+
+  it('filters common regions', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/regions')
+      .reply(200, [
+        {name: 'eu', description: 'Europe', private_capable: false},
+        {name: 'us', description: 'United States', private_capable: false}
+      ])
+    return cmd.run({flags: { common: true }})
+      .then(() => expect(cli.stdout).to.equal(`ID  Location       Runtime
+──  ─────────────  ──────────────
+eu  Europe         Common Runtime
+us  United States  Common Runtime
 `))
       .then(() => api.done())
   })


### PR DESCRIPTION
Minor improvements: Add flag `--private` to shows only private runtimes and flag `--common` to show only common runtimes.

/cc @heroku/dogwood @heroku/cedar