### PR TITLE
Show any queued release as pending

### DIFF
--- a/commands/releases/index.js
+++ b/commands/releases/index.js
@@ -11,7 +11,7 @@ function * run (context, heroku) {
   let descriptionWithStatus = function (d, r) {
     const width = () => process.stdout.columns > 80 ? process.stdout.columns : 80
     const trunc = (s, l) => truncate(s, {length: width() - (60 + l), omission: '…'})
-    let status = statusHelper.description(r, runningRelease)
+    let status = statusHelper.description(r, runningRelease, runningSlug)
     let sc = ''
     if (status !== undefined) {
       sc = cli.color[statusHelper.color(r.status)](status)
@@ -35,6 +35,12 @@ function * run (context, heroku) {
     header += ' - ' + cli.color['blue'](`Current: v${currentRelease.version}`)
   }
   let runningRelease = releases.filter((r) => r.status === 'pending').slice(-1)[0]
+  let runningSlug
+  if (runningRelease !== undefined) {
+    runningSlug = yield heroku.request({
+      path: `/apps/${context.app}/slugs/${runningRelease.slug.id}`
+    })
+  }
 
   if (context.flags.json) {
     cli.log(JSON.stringify(releases, null, 2))

--- a/commands/releases/index.js
+++ b/commands/releases/index.js
@@ -13,7 +13,7 @@ function * run (context, heroku) {
     const trunc = (s, l) => truncate(s, {length: width() - (60 + l), omission: '…'})
     let status = statusHelper.description(r, runningRelease, runningSlug)
     let sc = ''
-    if (status !== undefined) {
+    if (status) {
       sc = cli.color[statusHelper.color(r.status)](status)
     }
     return trunc(d, sc.length) + ' ' + sc
@@ -31,15 +31,13 @@ function * run (context, heroku) {
 
   let header = `${context.app} Releases`
   let currentRelease = releases.filter((r) => r.current === true)[0]
-  if (currentRelease !== undefined) {
+  if (currentRelease) {
     header += ' - ' + cli.color['blue'](`Current: v${currentRelease.version}`)
   }
   let runningRelease = releases.filter((r) => r.status === 'pending').slice(-1)[0]
   let runningSlug
-  if (runningRelease !== undefined) {
-    runningSlug = yield heroku.request({
-      path: `/apps/${context.app}/slugs/${runningRelease.slug.id}`
-    })
+  if (runningRelease) {
+    runningSlug = yield heroku.get(`/apps/${context.app}/slugs/${runningRelease.slug.id}`)
   }
 
   if (context.flags.json) {

--- a/commands/releases/index.js
+++ b/commands/releases/index.js
@@ -11,11 +11,10 @@ function * run (context, heroku) {
   let descriptionWithStatus = function (d, r) {
     const width = () => process.stdout.columns > 80 ? process.stdout.columns : 80
     const trunc = (s, l) => truncate(s, {length: width() - (60 + l), omission: '…'})
-
-    let status = statusHelper(r.status)
+    let status = statusHelper.description(r, runningRelease)
     let sc = ''
-    if (status.content !== undefined) {
-      sc = cli.color[status.color](status.content)
+    if (status !== undefined) {
+      sc = cli.color[statusHelper.color(r.status)](status)
     }
     return trunc(d, sc.length) + ' ' + sc
   }
@@ -35,6 +34,7 @@ function * run (context, heroku) {
   if (currentRelease !== undefined) {
     header += ' - ' + cli.color['blue'](`Current: v${currentRelease.version}`)
   }
+  let runningRelease = releases.filter((r) => r.status === 'pending').slice(-1)[0]
 
   if (context.flags.json) {
     cli.log(JSON.stringify(releases, null, 2))
@@ -43,7 +43,7 @@ function * run (context, heroku) {
     cli.table(releases, {
       printHeader: false,
       columns: [
-        {key: 'version', format: (v, r) => cli.color[statusHelper(r.status).color]('v' + v)},
+        {key: 'version', format: (v, r) => cli.color[statusHelper.color(r.status)]('v' + v)},
         {key: 'description', format: descriptionWithStatus},
         {key: 'user', format: (u) => cli.color.magenta(u.email.replace(/@addons\.heroku\.com$/, ''))},
         {key: 'created_at', format: (t) => time.ago(new Date(t))},
@@ -58,7 +58,7 @@ function * run (context, heroku) {
     cli.table(releases, {
       printHeader: false,
       columns: [
-        {key: 'version', label: '', format: (v, r) => cli.color[statusHelper(r.status).color]('v' + v)},
+        {key: 'version', label: '', format: (v, r) => cli.color[statusHelper.color(r.status)]('v' + v)},
         {key: 'description', format: descriptionWithStatus},
         {key: 'user', format: (u) => cli.color.magenta(u.email)},
         {key: 'created_at', format: (t) => time.ago(new Date(t))}

--- a/commands/releases/info.js
+++ b/commands/releases/info.js
@@ -40,9 +40,10 @@ function * run (context, heroku) {
     cli.styledJSON(release.v3)
   } else {
     let releaseChange = release.v3.description
-    let status = statusHelper(release.v3.status)
-    if (status.content !== undefined) {
-      releaseChange += ' (' + cli.color[status.color](status.content) + ')'
+    let status = statusHelper.description(release.v3)
+    let statusColor = statusHelper.color(release.v3.status)
+    if (status !== undefined) {
+      releaseChange += ' (' + cli.color[statusColor](status) + ')'
     }
 
     cli.styledHeader(`Release ${cli.color.cyan('v' + release.v3.version)}`)

--- a/commands/releases/status_helper.js
+++ b/commands/releases/status_helper.js
@@ -1,17 +1,21 @@
 'use strict'
 
-function pendingDescription (release, runningRelease) {
-  if (runningRelease !== undefined && runningRelease.id === release.id) {
+function pendingDescription (release, runningRelease, runningSlug) {
+  if (
+    runningRelease !== undefined &&
+    runningRelease.id === release.id &&
+    (runningSlug.process_types || {}).release !== undefined
+  ) {
     return 'release command executing'
   } else {
     return 'pending'
   }
 }
 
-module.exports.description = function (release, runningRelease) {
+module.exports.description = function (release, runningRelease, runningSlug) {
   switch (release.status) {
     case 'pending':
-      return pendingDescription(release, runningRelease)
+      return pendingDescription(release, runningRelease, runningSlug)
     case 'failed':
       return 'release command failed'
     default:

--- a/commands/releases/status_helper.js
+++ b/commands/releases/status_helper.js
@@ -1,11 +1,7 @@
 'use strict'
 
 function pendingDescription (release, runningRelease, runningSlug) {
-  if (
-    runningRelease !== undefined &&
-    runningRelease.id === release.id &&
-    (runningSlug.process_types || {}).release !== undefined
-  ) {
+  if (runningRelease && runningRelease.id === release.id && runningSlug.process_types && runningSlug.process_types.release) {
     return 'release command executing'
   } else {
     return 'pending'

--- a/commands/releases/status_helper.js
+++ b/commands/releases/status_helper.js
@@ -1,25 +1,31 @@
 'use strict'
 
-module.exports = function (s) {
-  switch (s) {
-    case 'succeeded':
-    case null:
-      return {
-        color: 'green'
-      }
+function pendingDescription (release, runningRelease) {
+  if (runningRelease !== undefined && runningRelease.id === release.id) {
+    return 'release command executing'
+  } else {
+    return 'pending'
+  }
+}
+
+module.exports.description = function (release, runningRelease) {
+  switch (release.status) {
     case 'pending':
-      return {
-        color: 'yellow',
-        content: 'release command executing'
-      }
+      return pendingDescription(release, runningRelease)
     case 'failed':
-      return {
-        color: 'red',
-        content: 'release command failed'
-      }
+      return 'release command failed'
     default:
-      return {
-        color: 'white'
-      }
+      return
+  }
+}
+
+module.exports.color = function (s) {
+  switch (s) {
+    case 'pending':
+      return 'yellow'
+    case 'failed':
+      return 'red'
+    default:
+      return 'white'
   }
 }

--- a/test/commands/releases/index.js
+++ b/test/commands/releases/index.js
@@ -11,6 +11,22 @@ describe('releases', () => {
 
   const releases = [
     {
+      'created_at': '2015-11-18T01:36:38Z',
+      'description': 'third commit',
+      'status': 'pending',
+      'id': '86b20c9f-f5de-4876-aa36-d3dcb1d60f6a',
+      'slug': {
+        'id': '37994c83-39a3-4cbf-b318-8f9dc648f701'
+      },
+      'updated_at': '2015-11-18T01:36:38Z',
+      'user': {
+        'email': 'jeff@heroku.com',
+        'id': '5985f8c9-a63f-42a2-bec7-40b875bb986f'
+      },
+      'version': 41,
+      'current': false
+    },
+    {
       'created_at': '2015-11-18T01:37:41Z',
       'description': 'Set foo config vars',
       'status': 'succeeded',
@@ -98,13 +114,22 @@ describe('releases', () => {
     }
   ]
 
+  const slug = {
+    process_types: {
+      release: 'bundle exec rake db:migrate'
+    }
+  }
+
   it('shows releases', () => {
     process.stdout.columns = 80
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, releases)
+      .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
+      .reply(200, slug)
     return cmd.run({app: 'myapp', flags: {}})
       .then(() => expect(cli.stdout, 'to equal', `=== myapp Releases - Current: v37
+v41  third commit pending         jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars          jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  … release command failed     jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  … release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
@@ -114,12 +139,33 @@ v37  first commit                 jeff@heroku.com  2015/11/18 01:36:38 +0000
       .then(() => api.done())
   })
 
+  it('shows pending releases without release phase', () => {
+    process.stdout.columns = 80
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/myapp/releases')
+      .reply(200, releases)
+      .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
+      .reply(200, {})
+    return cmd.run({app: 'myapp', flags: {}})
+      .then(() => expect(cli.stdout, 'to equal', `=== myapp Releases - Current: v37
+v41  third commit pending      jeff@heroku.com  2015/11/18 01:36:38 +0000
+v40  Set foo config vars       jeff@heroku.com  2015/11/18 01:37:41 +0000
+v39  … release command failed  jeff@heroku.com  2015/11/18 01:36:38 +0000
+v38  second commit pending     jeff@heroku.com  2015/11/18 01:36:38 +0000
+v37  first commit              jeff@heroku.com  2015/11/18 01:36:38 +0000
+`))
+      .then(() => expect(cli.stderr, 'to be empty'))
+      .then(() => api.done())
+  })
+
   it('shows releases as json', () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, releases)
+      .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
+      .reply(200, slug)
     return cmd.run({app: 'myapp', flags: {json: true}})
-      .then(() => expect(JSON.parse(cli.stdout)[0], 'to satisfy', {version: 40}))
+      .then(() => expect(JSON.parse(cli.stdout)[0], 'to satisfy', {version: 41}))
       .then(() => expect(cli.stderr, 'to be empty'))
       .then(() => api.done())
   })
@@ -153,8 +199,11 @@ v40      Set foo config vars   jeff@heroku.com  2015/11/18 01:37:41 +0000  1    
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, releases)
+      .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
+      .reply(200, slug)
     return cmd.run({app: 'myapp', flags: {}})
       .then(() => expect(cli.stdout, 'to equal', `=== myapp Releases
+v41  third commit pending         jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars          jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  … release command failed     jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  … release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000

--- a/test/commands/releases/info.js
+++ b/test/commands/releases/info.js
@@ -160,7 +160,7 @@ When:    ${d.toISOString()}
 Add-ons: addon1
          addon2
 By:      foo@foo.com
-Change:  something changed (release command executing)
+Change:  something changed (pending)
 When:    ${d.toISOString()}
 
 === v10 Config vars


### PR DESCRIPTION
We will soon create all releases as pending, regardless of the presence of release phase.
So we need to change the wording here, as a pending release doesn't mean we're running release phase anymore.

@dickeyxxx @ransombriggs I'd need to be able to fetch the slug for a release when looking up it's description, to know if it has a release phase command or not (and avoid showing "release command running" when there isn't any). I'm facing javascript/yield issues when doing so though. Could you advise me on the best way to do that?