### PR TITLE
Add IP addresses in the result of heroku ps -x

### DIFF
--- a/commands/ps/index.js
+++ b/commands/ps/index.js
@@ -20,6 +20,7 @@ function printExtended (dynos) {
       {key: 'state', label: 'State', format: (state, row) => `${state} ${time.ago(new Date(row.updated_at))}`},
       {key: 'extended.region', label: 'Region'},
       {key: 'extended.instance', label: 'Instance'},
+      {key: 'extended.ip', label: 'IP'},
       {key: 'extended.port', label: 'Port'},
       {key: 'extended.az', label: 'AZ'},
       {key: 'release.version', label: 'Release'},

--- a/test/commands/ps/index.js
+++ b/test/commands/ps/index.js
@@ -107,18 +107,18 @@ run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
       .get('/apps/myapp/dynos?extended=true')
       .reply(200, [
         {id: 100, command: 'npm start', size: 'Free', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up', extended: {
-          region: 'us', instance: 'instance', port: 8000, az: 'us-east', route: 'da route'
+          region: 'us', instance: 'instance', ip: '10.0.0.1', port: 8000, az: 'us-east', route: 'da route'
         }},
         {id: 101, command: 'bash', size: 'Free', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up', extended: {
-          region: 'us', instance: 'instance', port: 8000, az: 'us-east', route: 'da route'
+          region: 'us', instance: 'instance', ip: '10.0.0.2', port: 8000, az: 'us-east', route: 'da route'
         }}
       ])
 
     return cmd.run({app: 'myapp', args: [], flags: {extended: true}})
-      .then(() => expect(cli.stdout, 'to equal', `ID   Process  State                                    Region  Instance  Port  AZ       Release  Command    Route     Size
-───  ───────  ───────────────────────────────────────  ──────  ────────  ────  ───────  ───────  ─────────  ────────  ────
-101  run.1    up ${hourAgoStr} (~ 1h ago)  us      instance  8000  us-east           bash       da route  Free
-100  web.1    up ${hourAgoStr} (~ 1h ago)  us      instance  8000  us-east           npm start  da route  Free
+      .then(() => expect(cli.stdout, 'to equal', `ID   Process  State                                    Region  Instance  IP        Port  AZ       Release  Command    Route     Size
+───  ───────  ───────────────────────────────────────  ──────  ────────  ────────  ────  ───────  ───────  ─────────  ────────  ────
+101  run.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.2  8000  us-east           bash       da route  Free
+100  web.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.1  8000  us-east           npm start  da route  Free
 `))
       .then(() => expect(cli.stderr, 'to be empty'))
       .then(() => api.done())


### PR DESCRIPTION
Cedar and Dogwood are both sending back IPs, but they're not printed in `heroku ps -x` result. You can check out it's returned with `heroku ps -x --json`. This PR is to show it in `heroku ps -x`.

Following is just a memo:

Currently, dogwood _may_ be returning incorrect IPs (it's like `"10.0.155.64/20"` right now), which they're looking into.

These are different between cedar (above) and dogwood (below) currently in `extended`. For cedar, `instance` is referring ion instance id, but for dogwood, it's referring AWS instance id. Also, for dogwood, az and port and route (route_id, maybe not available on dogwood?) are not available.

```
    "extended": {
      "az": "us-east-1e",
      "instance": "1146464",
      "ip": "10.61.195.157",
      "port": "38320",
      "region": "us",
      "route": "3044757b-3fad-4461-8437-2d56444ac2db"
    }
```

```
    "extended": {
      "az": null,
      "instance": "i-ffdcd16f",
      "ip": "10.0.155.64/20",
      "port": null,
      "region": "virginia",
      "route": null
    }
```

cc/ @amerine 