### PR TITLE
added auth:whoami

### DIFF
--- a/commands/auth/whoami.js
+++ b/commands/auth/whoami.js
@@ -1,11 +1,9 @@
-'use strict'
-
-let cli = require('heroku-cli-util')
-let co = require('co')
+const cli = require('heroku-cli-util')
+const co = require('co')
 
 function notloggedin () {
   console.error('not logged in')
-  process.exit(100)
+  cli.exit(100)
 }
 
 function * run (context, heroku) {
@@ -20,9 +18,12 @@ function * run (context, heroku) {
   }
 }
 
-module.exports = {
-  topic: 'auth',
-  command: 'whoami',
+const cmd = {
   description: 'display the current logged in user',
   run: cli.command(co.wrap(run))
 }
+
+module.exports = [
+  Object.assign({topic: 'auth', command: 'whoami'}, cmd),
+  Object.assign({topic: 'whoami'}, cmd)
+]

--- a/commands/auth/whoami.js
+++ b/commands/auth/whoami.js
@@ -1,0 +1,23 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+let co = require('co')
+
+function notloggedin () {
+  console.error('not logged in')
+  process.exit(100)
+}
+
+function * run (context, heroku) {
+  if (process.env.HEROKU_API_KEY) cli.warn('HEROKU_API_KEY is set')
+  if (!context.auth.password) notloggedin()
+  let account = yield heroku.get('/account')
+  cli.log(account.email)
+}
+
+module.exports = {
+  topic: 'auth',
+  command: 'whoami',
+  description: 'display the current logged in user',
+  run: cli.command(co.wrap(run))
+}

--- a/commands/auth/whoami.js
+++ b/commands/auth/whoami.js
@@ -11,8 +11,13 @@ function notloggedin () {
 function * run (context, heroku) {
   if (process.env.HEROKU_API_KEY) cli.warn('HEROKU_API_KEY is set')
   if (!context.auth.password) notloggedin()
-  let account = yield heroku.get('/account')
-  cli.log(account.email)
+  try {
+    let account = yield heroku.get('/account')
+    cli.log(account.email)
+  } catch (err) {
+    if (err.statusCode === 401) notloggedin()
+    throw err
+  }
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ exports.commands = flatten([
   require('./commands/apps/rename'),
   require('./commands/apps/stacks'),
   require('./commands/apps/stacks/set'),
+  require('./commands/auth/whoami'),
   require('./commands/buildpacks'),
   require('./commands/buildpacks/add.js'),
   require('./commands/buildpacks/clear.js'),

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "co": "4.6.0",
     "co-wait": "0.0.0",
     "filesize": "3.5.4",
-    "heroku-cli-util": "heroku/heroku-cli-util#netrc",
+    "heroku-cli-util": "heroku/heroku-cli-util#af3749d",
     "inquirer": "3.0.1",
     "lodash": "4.17.4",
     "lodash.compact": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "co": "4.6.0",
     "co-wait": "0.0.0",
     "filesize": "3.5.4",
-    "heroku-cli-util": "6.1.6",
+    "heroku-cli-util": "heroku/heroku-cli-util#netrc",
     "inquirer": "3.0.1",
     "lodash": "4.17.4",
     "lodash.compact": "3.0.1",

--- a/test/commands/auth/whoami.js
+++ b/test/commands/auth/whoami.js
@@ -1,0 +1,25 @@
+'use strict'
+/* globals commands, describe beforeEach afterEach it */
+
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+
+// get command from index.js
+const cmd = commands.find(c => c.topic === 'auth' && c.command === 'whoami')
+const expect = require('unexpected')
+
+describe('auth:whoami', () => {
+  beforeEach(() => cli.mockConsole())
+  afterEach(() => nock.cleanAll())
+
+  it('shows logged in user', () => {
+    let api = nock('https://api.heroku.com:443')
+      .get('/account')
+      .reply(200, {email: 'foo@bar.com'})
+
+    return cmd.run({auth: {password: 'foobar'}})
+      .then(() => expect(cli.stdout, 'to equal', 'foo@bar.com\n'))
+      .then(() => expect(cli.stderr, 'to be empty'))
+      .then(() => api.done())
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,16 +211,16 @@ babel-messages@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-runtime@6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
+babel-runtime@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.22.0.tgz#1cf8b4ac67c77a4ddb0db2ae1f74de52ac4ca611"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-runtime@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.22.0.tgz#1cf8b4ac67c77a4ddb0db2ae1f74de52ac4ca611"
+babel-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
@@ -1175,9 +1175,9 @@ here@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/here/-/here-0.0.2.tgz#69c1af3f02121f3d8788e02e84dc8b3905d71195"
 
-heroku-cli-util@6.1.6:
+heroku-cli-util@heroku/heroku-cli-util#af3749d:
   version "6.1.6"
-  resolved "https://registry.yarnpkg.com/heroku-cli-util/-/heroku-cli-util-6.1.6.tgz#1be370d01faed4ea175cc998129f9ebe514b1bb9"
+  resolved "https://codeload.github.com/heroku/heroku-cli-util/tar.gz/af3749d"
   dependencies:
     ansi-escapes "1.4.0"
     cardinal "1.0.0"
@@ -1197,33 +1197,7 @@ heroku-cli-util@6.1.6:
     lodash.property "4.4.2"
     lodash.repeat "4.1.0"
     lodash.result "4.5.2"
-    opn "^3.0.3"
-    supports-color "^3.1.2"
-    tunnel-agent "^0.4.3"
-
-heroku-cli-util@heroku/heroku-cli-util#netrc:
-  version "6.1.6"
-  resolved "https://codeload.github.com/heroku/heroku-cli-util/tar.gz/bb56ef6dff697549c74c24281f0d60435a0aff92"
-  dependencies:
-    ansi-escapes "1.4.0"
-    cardinal "1.0.0"
-    chalk "^1.1.3"
-    co "4.6.0"
-    got "^6.3.0"
-    heroku-client "3.0.2"
-    lodash.ary "4.1.1"
-    lodash.defaults "4.2.0"
-    lodash.get "4.4.2"
-    lodash.identity "3.0.0"
-    lodash.keys "4.2.0"
-    lodash.mapvalues "4.6.0"
-    lodash.noop "3.0.1"
-    lodash.partial "4.2.1"
-    lodash.pickby "4.6.0"
-    lodash.property "4.4.2"
-    lodash.repeat "4.1.0"
-    lodash.result "4.5.2"
-    netrc-parser "1.0.0"
+    netrc-parser "1.0.5"
     opn "^3.0.3"
     supports-color "^3.1.2"
     tunnel-agent "^0.4.3"
@@ -1630,7 +1604,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lex@1.7.9:
+lex@^1.7.9:
   version "1.7.9"
   resolved "https://registry.yarnpkg.com/lex/-/lex-1.7.9.tgz#5d5636ccef574348362938b79a47f0eed8ed0d43"
 
@@ -2016,12 +1990,12 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-netrc-parser@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/netrc-parser/-/netrc-parser-1.0.0.tgz#707fb16b8801b664dc344e60a2b0f19491c9cf2c"
+netrc-parser@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/netrc-parser/-/netrc-parser-1.0.5.tgz#5692eac39b759e6352cf0c419994d633aec1cab0"
   dependencies:
-    babel-runtime "6.23.0"
-    lex "1.7.9"
+    babel-runtime "^6.23.0"
+    lex "^1.7.9"
 
 nock@9.0.4:
   version "9.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,6 +211,13 @@ babel-messages@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-runtime@6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-runtime@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.22.0.tgz#1cf8b4ac67c77a4ddb0db2ae1f74de52ac4ca611"
@@ -1194,6 +1201,33 @@ heroku-cli-util@6.1.6:
     supports-color "^3.1.2"
     tunnel-agent "^0.4.3"
 
+heroku-cli-util@heroku/heroku-cli-util#netrc:
+  version "6.1.6"
+  resolved "https://codeload.github.com/heroku/heroku-cli-util/tar.gz/bb56ef6dff697549c74c24281f0d60435a0aff92"
+  dependencies:
+    ansi-escapes "1.4.0"
+    cardinal "1.0.0"
+    chalk "^1.1.3"
+    co "4.6.0"
+    got "^6.3.0"
+    heroku-client "3.0.2"
+    lodash.ary "4.1.1"
+    lodash.defaults "4.2.0"
+    lodash.get "4.4.2"
+    lodash.identity "3.0.0"
+    lodash.keys "4.2.0"
+    lodash.mapvalues "4.6.0"
+    lodash.noop "3.0.1"
+    lodash.partial "4.2.1"
+    lodash.pickby "4.6.0"
+    lodash.property "4.4.2"
+    lodash.repeat "4.1.0"
+    lodash.result "4.5.2"
+    netrc-parser "1.0.0"
+    opn "^3.0.3"
+    supports-color "^3.1.2"
+    tunnel-agent "^0.4.3"
+
 heroku-client@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/heroku-client/-/heroku-client-3.0.2.tgz#7e06f303ff18f7a0731725dcccbe210b76198657"
@@ -1596,6 +1630,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lex@1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/lex/-/lex-1.7.9.tgz#5d5636ccef574348362938b79a47f0eed8ed0d43"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -1977,6 +2015,13 @@ mz@2.6.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+netrc-parser@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/netrc-parser/-/netrc-parser-1.0.0.tgz#707fb16b8801b664dc344e60a2b0f19491c9cf2c"
+  dependencies:
+    babel-runtime "6.23.0"
+    lex "1.7.9"
 
 nock@9.0.4:
   version "9.0.4"


### PR DESCRIPTION
@ransombriggs this is because sometimes `whoami` errors out with a strange error and we need to convert this code to js eventually anyways:

```
~ > debug h auth:whoami
heroku-cli/5.6.10-249d061 (darwin-amd64) go1.7.4 /Users/rwz/.local/share/heroku/cli/bin/heroku cmd: version
heroku-cli/5.6.10-249d061 (darwin-amd64) go1.7.4 /Users/rwz/.local/share/heroku/cli/bin/heroku cmd: commands
heroku-cli/5.6.10-249d061 (darwin-amd64) go1.7.4 /Users/rwz/.local/share/heroku/cli/bin/heroku cmd: auth:whoami
 ▸    runtime error: invalid memory address or nil pointer dereference
runtime error: invalid memory address or nil pointer dereference
/home/ubuntu/.go_workspace/src/github.com/heroku/cli/io.go:328 (0x16820)
/usr/local/go/src/runtime/asm_amd64.s:479 (0x7cc3c)
/usr/local/go/src/runtime/panic.go:458 (0x505a3)
/usr/local/go/src/runtime/panic.go:62 (0x4f0fd)
/usr/local/go/src/runtime/sigpanic_unix.go:24 (0x655f4)
/home/ubuntu/.go_workspace/src/github.com/heroku/cli/auth.go:244 (0x4a11)
/home/ubuntu/.go_workspace/src/github.com/heroku/cli/auth.go:193 (0x40a8)
/home/ubuntu/.go_workspace/src/github.com/heroku/cli/start.go:70 (0x1ee4e)
/home/ubuntu/.go_workspace/src/github.com/heroku/cli/main.go:22 (0x1765a)
/usr/local/go/src/runtime/proc.go:183 (0x52274)
/usr/local/go/src/runtime/asm_amd64.s:2086 (0x7f761)
```

cc @rwz 

depends on https://github.com/heroku/heroku-cli-util/pull/83

will also need a change to remove whoami from heroku/cli