### PR TITLE
Display dynos for apps in shielded spaces as Shield dynos

### DIFF
--- a/commands/ps/index.js
+++ b/commands/ps/index.js
@@ -111,15 +111,20 @@ function * run (context, heroku) {
     dynos: heroku.request({path: `/apps/${app}/dynos${suffix}`})
   }
 
-  if (!json && !extended) {
-    promises.app_info = heroku.request({
-      path: `/apps/${context.app}`,
-      headers: {Accept: 'application/vnd.heroku+json; version=3.process-tier'}
-    })
-    promises.account_info = heroku.request({path: '/account'})
-  }
+  promises.app_info = heroku.request({
+    path: `/apps/${context.app}`,
+    headers: {Accept: 'application/vnd.heroku+json; version=3.process-tier'}
+  })
+  promises.account_info = heroku.request({path: '/account'})
 
   let {dynos, app_info, account_info} = yield promises
+  const shielded = app_info.space && app_info.space.shield
+
+  if (shielded) {
+    dynos.forEach(d => {
+      d.size = d.size.replace('Private-', 'Shield-')
+    })
+  }
 
   if (types.length > 0) {
     dynos = dynos.filter(dyno => types.find(t => dyno.type === t))

--- a/commands/ps/scale.js
+++ b/commands/ps/scale.js
@@ -18,7 +18,7 @@ function * run (context, heroku) {
       let change = arg.match(/^([a-zA-Z0-9_]+)([=+-]\d+)(?::([\w-]+))?$/)
       if (!change) return
       let quantity = change[2][0] === '=' ? change[2].substr(1) : change[2]
-      change[3] = change[3].replace('Shield-', 'Private-')
+      if (change[3]) change[3] = change[3].replace('Shield-', 'Private-')
       return {type: change[1], quantity, size: change[3]}
     }))
   }
@@ -40,6 +40,13 @@ function * run (context, heroku) {
   } else {
     yield cli.action('Scaling dynos', {success: false}, co(function * () {
       let formation = yield heroku.request({method: 'PATCH', path: `/apps/${app}/formation`, body: {updates: changes}})
+      const appProps = yield heroku.get(`/apps/${app}`)
+      const shielded = appProps.space && appProps.space.shield
+      if (shielded) {
+        formation.forEach((d) => {
+          d.size = d.size.replace('Private-', 'Shield-')
+        })
+      }
       let output = formation.filter((f) => changes.find((c) => c.type === f.type))
         .map((d) => `${cli.color.green(d.type)} at ${d.quantity}:${d.size}`)
       cli.action.done(`done, now running ${output.join(', ')}`)

--- a/commands/ps/type.js
+++ b/commands/ps/type.js
@@ -38,7 +38,19 @@ Types: ${cli.color.yellow(formation.map((f) => f.type).join(', '))}`)
 
   let displayFormation = co.wrap(function * () {
     let formation = yield heroku.get(`/apps/${app}/formation`)
+    let shielded = yield heroku.get(`/apps/${app}`)
+
+    shielded = shielded.space && shielded.space.shield
     formation = sortBy(formation, 'type')
+
+    formation.forEach((d) => {
+      if (shielded && d.size === 'Private-M') {
+        d.size = 'Shield-M'
+      } else if (shielded && d.size === 'Private-L') {
+        d.size = 'Shield-L'
+      }
+    })
+
     formation = formation.map((d) => ({
       type: cli.color.green(d.type),
       size: cli.color.cyan(d.size),

--- a/commands/ps/type.js
+++ b/commands/ps/type.js
@@ -42,10 +42,11 @@ Types: ${cli.color.yellow(formation.map((f) => f.type).join(', '))}`)
     const shielded = appProps.space && appProps.space.shield
 
     formation = sortBy(formation, 'type')
-
-    formation.forEach((d) => {
-      if (shielded) { d.size = d.size.replace('Private-', 'Shield-') }
-    })
+    if (shielded) {
+      formation.forEach((d) => {
+        d.size = d.size.replace('Private-', 'Shield-')
+      })
+    }
 
     formation = formation.map((d) => ({
       type: cli.color.green(d.type),

--- a/commands/ps/type.js
+++ b/commands/ps/type.js
@@ -38,17 +38,13 @@ Types: ${cli.color.yellow(formation.map((f) => f.type).join(', '))}`)
 
   let displayFormation = co.wrap(function * () {
     let formation = yield heroku.get(`/apps/${app}/formation`)
-    let shielded = yield heroku.get(`/apps/${app}`)
+    const appProps = yield heroku.get(`/apps/${app}`)
+    const shielded = appProps.space && appProps.space.shield
 
-    shielded = shielded.space && shielded.space.shield
     formation = sortBy(formation, 'type')
 
     formation.forEach((d) => {
-      if (shielded && d.size === 'Private-M') {
-        d.size = 'Shield-M'
-      } else if (shielded && d.size === 'Private-L') {
-        d.size = 'Shield-L'
-      }
+      if (shielded) { d.size = d.size.replace('Private-', 'Shield-') }
     })
 
     formation = formation.map((d) => ({

--- a/test/commands/ps/scale.js
+++ b/test/commands/ps/scale.js
@@ -15,9 +15,24 @@ describe('ps:scale', () => {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp/formation')
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
+      .get('/apps/myapp')
+      .reply(200, {name: 'myapp'})
 
     return cmd.run({app: 'myapp', args: []})
       .then(() => expect(cli.stdout, 'to equal', 'web=1:Free worker=2:Free\n'))
+      .then(() => expect(cli.stderr, 'to be empty'))
+      .then(() => api.done())
+  })
+
+  it('shows formation with shield dynos for apps in a shielded private space', () => {
+    let api = nock('https://api.heroku.com')
+      .get('/apps/myapp/formation')
+      .reply(200, [{type: 'web', quantity: 1, size: 'Private-L'}, {type: 'worker', quantity: 2, size: 'Private-M'}])
+      .get('/apps/myapp')
+      .reply(200, {name: 'myapp', space: {shield: true}})
+
+    return cmd.run({app: 'myapp', args: []})
+      .then(() => expect(cli.stdout, 'to equal', 'web=1:Shield-L worker=2:Shield-M\n'))
       .then(() => expect(cli.stderr, 'to be empty'))
       .then(() => api.done())
   })
@@ -26,6 +41,8 @@ describe('ps:scale', () => {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp/formation')
       .reply(200, [])
+      .get('/apps/myapp')
+      .reply(200, {name: 'myapp'})
 
     return expect(cmd.run({app: 'myapp', args: []}),
       'to be rejected with', {message: /^No process types on myapp./})
@@ -35,9 +52,11 @@ describe('ps:scale', () => {
   })
 
   it('scales web=1 worker=2', () => {
-    let api = nock('https://api.heroku.com')
+    let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp/formation', {updates: [{type: 'web', quantity: '1'}, {type: 'worker', quantity: '2'}]})
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
+      .get('/apps/myapp')
+      .reply(200, {name: 'myapp'})
 
     return cmd.run({app: 'myapp', args: ['web=1', 'worker=2']})
       .then(() => expect(cli.stdout, 'to be empty'))
@@ -45,10 +64,25 @@ describe('ps:scale', () => {
       .then(() => api.done())
   })
 
+  it('scales up a shield dyno if the app is in a shielded private space', () => {
+    let api = nock('https://api.heroku.com:443')
+      .patch('/apps/myapp/formation', {updates: [{type: 'web', quantity: '1', size: 'Private-L'}]})
+      .reply(200, [{type: 'web', quantity: 1, size: 'Private-L'}])
+      .get('/apps/myapp')
+      .reply(200, {name: 'myapp', space: {shield: true}})
+
+    return cmd.run({app: 'myapp', args: ['web=1:Shield-L']})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(cli.stderr, 'to equal', 'Scaling dynos... done, now running web at 1:Shield-L\n'))
+      .then(() => api.done())
+  })
+
   it('scales web-1', () => {
-    let api = nock('https://api.heroku.com')
+    let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp/formation', {updates: [{type: 'web', quantity: '+1'}]})
       .reply(200, [{type: 'web', quantity: 2, size: 'Free'}])
+      .get('/apps/myapp')
+      .reply(200, {name: 'myapp'})
 
     return cmd.run({app: 'myapp', args: ['web+1']})
       .then(() => expect(cli.stdout, 'to be empty'))

--- a/test/commands/ps/type.js
+++ b/test/commands/ps/type.js
@@ -6,9 +6,9 @@ const cmd = commands.find((c) => c.topic === 'ps' && c.command === 'type')
 const nock = require('nock')
 const expect = require('chai').expect
 
-let app = {
-  name: 'myapp',
-  space: {name: 'sample-space', shield: true}
+function app (args = {}) {
+  let base = {name: 'myapp'}
+  return Object.assign(base, args)
 }
 
 describe('ps:type', function () {
@@ -20,7 +20,7 @@ describe('ps:type', function () {
   it('switches to hobby dynos', function () {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp')
-      .reply(200, app)
+      .reply(200, app())
       .get('/apps/myapp/formation')
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
       .patch('/apps/myapp/formation', {updates: [{type: 'web', size: 'hobby'}, {type: 'worker', size: 'hobby'}]})
@@ -41,7 +41,7 @@ worker  Hobby  2    14
   it('switches to standard-1x and standard-2x dynos', function () {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp')
-      .reply(200, app)
+      .reply(200, app())
       .get('/apps/myapp/formation')
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
       .patch('/apps/myapp/formation', {updates: [{type: 'web', size: 'standard-1x'}, {type: 'worker', size: 'standard-2x'}]})
@@ -62,7 +62,7 @@ worker  Standard-2X  2    100
   it('displays Shield dynos for apps in shielded spaces', function () {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp')
-      .reply(200, app)
+      .reply(200, app({space: {shield: true}}))
       .get('/apps/myapp/formation')
       .reply(200, [{type: 'web', quantity: 0, size: 'Private-M'}, {type: 'web', quantity: 0, size: 'Private-L'}])
 

--- a/test/commands/ps/type.js
+++ b/test/commands/ps/type.js
@@ -6,6 +6,11 @@ const cmd = commands.find((c) => c.topic === 'ps' && c.command === 'type')
 const nock = require('nock')
 const expect = require('chai').expect
 
+let app = {
+  name: 'myapp',
+  space: {name: 'sample-space', shield: true}
+}
+
 describe('ps:type', function () {
   beforeEach(function () {
     cli.mockConsole()
@@ -14,6 +19,8 @@ describe('ps:type', function () {
 
   it('switches to hobby dynos', function () {
     let api = nock('https://api.heroku.com')
+      .get('/apps/myapp')
+      .reply(200, app)
       .get('/apps/myapp/formation')
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
       .patch('/apps/myapp/formation', {updates: [{type: 'web', size: 'hobby'}, {type: 'worker', size: 'hobby'}]})
@@ -33,6 +40,8 @@ worker  Hobby  2    14
 
   it('switches to standard-1x and standard-2x dynos', function () {
     let api = nock('https://api.heroku.com')
+      .get('/apps/myapp')
+      .reply(200, app)
       .get('/apps/myapp/formation')
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
       .patch('/apps/myapp/formation', {updates: [{type: 'web', size: 'standard-1x'}, {type: 'worker', size: 'standard-2x'}]})
@@ -47,6 +56,22 @@ web     Standard-1X  1    25
 worker  Standard-2X  2    100
 `))
       .then(() => expect(cli.stderr).to.eq('Scaling dynos on myapp... done\n'))
+      .then(() => api.done())
+  })
+
+  it('displays Shield dynos for apps in shielded spaces', function () {
+    let api = nock('https://api.heroku.com')
+      .get('/apps/myapp')
+      .reply(200, app)
+      .get('/apps/myapp/formation')
+      .reply(200, [{type: 'web', quantity: 0, size: 'Private-M'}, {type: 'web', quantity: 0, size: 'Private-L'}])
+
+    return cmd.run({app: 'myapp', args: []})
+      .then(() => expect(cli.stdout).to.eq(`type  size      qty  cost/mo
+────  ────────  ───  ───────
+web   Shield-M  0
+web   Shield-L  0
+`))
       .then(() => api.done())
   })
 })


### PR DESCRIPTION
Hi @dickeyxxx and @ransombriggs! For compliance reasons, we need to display the dynos for apps that are in Private Spaces as "Shield-*" sizes. So dynos that would normally display as "Private-M" or "Private-L" will now display as "Shield-M" and "Shield-L" respectively for apps that are in Shielded Private Spaces.