### PR TITLE
Fix tests when stdin is not a tty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heroku-apps",
   "description": "Heroku CLI plugin to manage apps.",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "author": "Jeff Dickey (@dickeyxxx)",
   "bugs": {
     "url": "https://github.com/heroku/heroku-apps/issues"


### PR DESCRIPTION
This fixes the test suite when stdin is not a tty (during `np` basically), can be verified by running `echo '' | npm test`