### PR TITLE
Introduce new `releases:output` command

### DIFF
--- a/commands/releases/info.js
+++ b/commands/releases/info.js
@@ -11,12 +11,7 @@ function * run (context, heroku) {
 
   let release = yield releases.FindByLatestOrId(heroku, context.app, context.args.release)
 
-  let config = yield heroku.request({
-    path: `/apps/${context.app}/releases/${release.version}/config-vars`,
-    headers: {
-      Accept: 'application/vnd.heroku+json; version=3'
-    }
-  })
+  let config = yield heroku.get(`/apps/${context.app}/releases/${release.version}/config-vars`)
 
   if (context.flags.json) {
     cli.styledJSON(release)

--- a/commands/releases/info.js
+++ b/commands/releases/info.js
@@ -2,6 +2,7 @@
 
 const cli = require('heroku-cli-util')
 const co = require('co')
+let releases = require('../../lib/releases')
 
 function * run (context, heroku) {
   const shellescape = require('shell-escape')
@@ -10,14 +11,8 @@ function * run (context, heroku) {
   let id = (context.args.release || 'current').toLowerCase()
   id = id.startsWith('v') ? id.slice(1) : id
   if (id === 'current') {
-    let releases = yield heroku.request({
-      path: `/apps/${context.app}/releases`,
-      partial: true,
-      headers: {
-        Range: 'version ..; max=1, order=desc'
-      }
-    })
-    id = releases[0].version
+    let release = yield releases.FindRelease(heroku, context.app, (releases) => releases[0])
+    id = release.version
   }
 
   let data = yield {

--- a/commands/releases/info.js
+++ b/commands/releases/info.js
@@ -8,52 +8,40 @@ function * run (context, heroku) {
   const shellescape = require('shell-escape')
   const statusHelper = require('./status_helper')
   const forEach = require('lodash.foreach')
-  let id = (context.args.release || 'current').toLowerCase()
-  id = id.startsWith('v') ? id.slice(1) : id
-  if (id === 'current') {
-    let release = yield releases.FindRelease(heroku, context.app, (releases) => releases[0])
-    id = release.version
-  }
 
-  let data = yield {
-    release: heroku.request({
-      path: `/apps/${context.app}/releases/${id}`,
-      headers: {
-        Accept: 'application/vnd.heroku+json; version=3'
-      }
-    }),
-    config: heroku.request({
-      path: `/apps/${context.app}/releases/${id}/config-vars`,
-      headers: {
-        Accept: 'application/vnd.heroku+json; version=3'
-      }
-    })
-  }
+  let release = yield releases.FindByLatestOrId(heroku, context.app, context.args.release)
+
+  let config = yield heroku.request({
+    path: `/apps/${context.app}/releases/${release.version}/config-vars`,
+    headers: {
+      Accept: 'application/vnd.heroku+json; version=3'
+    }
+  })
 
   if (context.flags.json) {
-    cli.styledJSON(data.release)
+    cli.styledJSON(release)
   } else {
-    let releaseChange = data.release.description
-    let status = statusHelper.description(data.release)
-    let statusColor = statusHelper.color(data.release.status)
+    let releaseChange = release.description
+    let status = statusHelper.description(release)
+    let statusColor = statusHelper.color(release.status)
     if (status !== undefined) {
       releaseChange += ' (' + cli.color[statusColor](status) + ')'
     }
 
-    cli.styledHeader(`Release ${cli.color.cyan('v' + data.release.version)}`)
+    cli.styledHeader(`Release ${cli.color.cyan('v' + release.version)}`)
     cli.styledObject({
-      'Add-ons': data.release.addon_plan_names,
+      'Add-ons': release.addon_plan_names,
       Change: releaseChange,
-      By: data.release.user.email,
-      When: data.release.created_at
+      By: release.user.email,
+      When: release.created_at
     })
 
     cli.log()
-    cli.styledHeader(`${cli.color.cyan('v' + data.release.version)} Config vars`)
+    cli.styledHeader(`${cli.color.cyan('v' + release.version)} Config vars`)
     if (context.flags.shell) {
-      forEach(data.config, (v, k) => cli.log(`${k}=${shellescape([v])}`))
+      forEach(config, (v, k) => cli.log(`${k}=${shellescape([v])}`))
     } else {
-      cli.styledObject(data.config)
+      cli.styledObject(config)
     }
   }
 }

--- a/commands/releases/output.js
+++ b/commands/releases/output.js
@@ -4,10 +4,6 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 
 function * run (context, heroku) {
-  function getRelease (id) {
-    return heroku.get(`/apps/${context.app}/releases/${id}`)
-  }
-
   function getLatestRelease () {
     return heroku.request({
       path: `/apps/${context.app}/releases`,
@@ -20,7 +16,7 @@ function * run (context, heroku) {
   if (context.args.release) {
     let id = context.args.release.toLowerCase()
     id = id.startsWith('v') ? id.slice(1) : id
-    release = yield getRelease(id)
+    release = yield heroku.get(`/apps/${context.app}/releases/${id}`)
   } else {
     release = yield getLatestRelease()
   }

--- a/commands/releases/output.js
+++ b/commands/releases/output.js
@@ -2,23 +2,16 @@
 
 let cli = require('heroku-cli-util')
 let co = require('co')
+let releases = require('../../lib/releases')
 
 function * run (context, heroku) {
-  function getLatestRelease () {
-    return heroku.request({
-      path: `/apps/${context.app}/releases`,
-      partial: true,
-      headers: { 'Range': 'version ..; max=1, order=desc' }
-    }).then((releases) => releases[0])
-  }
-
   let release
   if (context.args.release) {
     let id = context.args.release.toLowerCase()
     id = id.startsWith('v') ? id.slice(1) : id
     release = yield heroku.get(`/apps/${context.app}/releases/${id}`)
   } else {
-    release = yield getLatestRelease()
+    release = yield releases.FindRelease(heroku, context.app, (releases) => releases[0])
   }
   let streamUrl = release.output_stream_url
 

--- a/commands/releases/output.js
+++ b/commands/releases/output.js
@@ -2,7 +2,6 @@
 
 let cli = require('heroku-cli-util')
 let co = require('co')
-let request = require('request')
 
 function * run (context, heroku) {
   function getRelease (id) {
@@ -33,7 +32,7 @@ function * run (context, heroku) {
   }
 
   yield new Promise(function (resolve, reject) {
-    request(streamUrl)
+    cli.got.stream(streamUrl)
       .on('error', reject)
       .on('end', resolve)
       .on('data', function (c) {

--- a/commands/releases/output.js
+++ b/commands/releases/output.js
@@ -26,7 +26,7 @@ function * run (context, heroku) {
   }
   let streamUrl = release.output_stream_url
 
-  if (streamUrl === undefined || streamUrl === null) {
+  if (!streamUrl) {
     cli.warn(`Release v${release.version} has no release output available.`)
     return
   }

--- a/commands/releases/output.js
+++ b/commands/releases/output.js
@@ -1,0 +1,53 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+let co = require('co')
+let request = require('request')
+
+function * run (context, heroku) {
+  function getRelease (id) {
+    return heroku.get(`/apps/${context.app}/releases/${id}`)
+  }
+
+  function getLatestRelease () {
+    return heroku.request({
+      path: `/apps/${context.app}/releases`,
+      partial: true,
+      headers: { 'Range': 'version ..; max=1, order=desc' }
+    }).then((releases) => releases[0])
+  }
+
+  let release
+  if (context.args.release) {
+    let id = context.args.release.toLowerCase()
+    id = id.startsWith('v') ? id.slice(1) : id
+    release = yield getRelease(id)
+  } else {
+    release = yield getLatestRelease()
+  }
+  let streamUrl = release.output_stream_url
+
+  if (streamUrl === undefined || streamUrl === null) {
+    cli.warn(`Release v${release.version} has no release output available.`)
+    return
+  }
+
+  yield new Promise(function (resolve, reject) {
+    request(streamUrl)
+      .on('error', reject)
+      .on('end', resolve)
+      .on('data', function (c) {
+        cli.log(c.toString('utf8'))
+      })
+  })
+}
+
+module.exports = {
+  topic: 'releases',
+  command: 'output',
+  description: 'View the release command output',
+  needsAuth: true,
+  needsApp: true,
+  args: [{name: 'release', optional: true}],
+  run: cli.command({preauth: true}, co.wrap(run))
+}

--- a/commands/releases/rollback.js
+++ b/commands/releases/rollback.js
@@ -2,23 +2,16 @@
 
 let cli = require('heroku-cli-util')
 let co = require('co')
+let releases = require('../../lib/releases')
 
 function * run (context, heroku) {
-  function findRollbackRelease () {
-    return heroku.request({
-      path: `/apps/${context.app}/releases`,
-      partial: true,
-      headers: { 'Range': 'version ..; max=2, order=desc' }
-    }).then((releases) => releases.filter((r) => r.status === 'succeeded')[1])
-  }
-
   let release
   if (context.args.release) {
     let id = context.args.release.toLowerCase()
     id = id.startsWith('v') ? id.slice(1) : id
     release = yield heroku.get(`/apps/${context.app}/releases/${id}`)
   } else {
-    release = yield findRollbackRelease()
+    release = yield releases.FindRelease(heroku, context.app, (releases) => releases.filter((r) => r.status === 'succeeded')[1])
   }
 
   yield cli.action(`Rolling back ${cli.color.app(context.app)} to ${cli.color.green('v' + release.version)}`, {success: false}, co(function * () {

--- a/commands/releases/rollback.js
+++ b/commands/releases/rollback.js
@@ -4,11 +4,7 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 
 function * run (context, heroku) {
-  function getRelease (id) {
-    return heroku.get(`/apps/${context.app}/releases/${id}`)
-  }
-
-  function getLatestRelease () {
+  function findRollbackRelease () {
     return heroku.request({
       path: `/apps/${context.app}/releases`,
       partial: true,
@@ -20,9 +16,9 @@ function * run (context, heroku) {
   if (context.args.release) {
     let id = context.args.release.toLowerCase()
     id = id.startsWith('v') ? id.slice(1) : id
-    release = yield getRelease(id)
+    release = yield heroku.get(`/apps/${context.app}/releases/${id}`)
   } else {
-    release = yield getLatestRelease()
+    release = yield findRollbackRelease()
   }
 
   yield cli.action(`Rolling back ${cli.color.app(context.app)} to ${cli.color.green('v' + release.version)}`, {success: false}, co(function * () {

--- a/index.js
+++ b/index.js
@@ -81,5 +81,6 @@ exports.commands = flatten([
   require('./commands/regions'),
   require('./commands/releases'),
   require('./commands/releases/info'),
-  require('./commands/releases/rollback')
+  require('./commands/releases/rollback'),
+  require('./commands/releases/output')
 ])

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = {
+  FindRelease: function (heroku, app, search) {
+    return heroku.request({
+      path: `/apps/${app}/releases`,
+      partial: true,
+      headers: { 'Range': 'version ..; max=10, order=desc' }
+    }).then(search)
+  }
+}

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -1,11 +1,24 @@
 'use strict'
 
-module.exports = {
-  FindRelease: function (heroku, app, search) {
-    return heroku.request({
-      path: `/apps/${app}/releases`,
-      partial: true,
-      headers: { 'Range': 'version ..; max=10, order=desc' }
-    }).then(search)
+let FindRelease = function (heroku, app, search) {
+  return heroku.request({
+    path: `/apps/${app}/releases`,
+    partial: true,
+    headers: { 'Range': 'version ..; max=10, order=desc' }
+  }).then(search)
+}
+
+let FindByLatestOrId = function (heroku, app, release) {
+  let id = (release || 'current').toLowerCase()
+  id = id.startsWith('v') ? id.slice(1) : id
+  if (id === 'current') {
+    return FindRelease(heroku, app, (releases) => releases[0])
+  } else {
+    return heroku.get(`/apps/${app}/releases/${id}`)
   }
+}
+
+module.exports = {
+  FindRelease,
+  FindByLatestOrId
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "proxyquire": "1.7.11",
     "rimraf": "2.5.4",
     "standard": "8.6.0",
+    "std-mocks": "1.0.1",
     "testdouble": "2.0.1",
     "time-require": "0.1.2",
     "unexpected": "10.25.0"

--- a/test/commands/releases/info.js
+++ b/test/commands/releases/info.js
@@ -26,10 +26,7 @@ describe('releases:info', function () {
   it('shows most recent release info', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-      .get('/apps/myapp/releases/10')
-      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
-      .reply(200, release)
+      .reply(200, [release])
       .get('/apps/myapp/releases/10/config-vars')
       .matchHeader('accept', 'application/vnd.heroku+json; version=3')
       .reply(200, configVars)
@@ -52,10 +49,7 @@ FOO: foo
   it('shows most recent release info config vars as shell', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-      .get('/apps/myapp/releases/10')
-      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
-      .reply(200, release)
+      .reply(200, [release])
       .get('/apps/myapp/releases/10/config-vars')
       .matchHeader('accept', 'application/vnd.heroku+json; version=3')
       .reply(200, configVars)
@@ -116,16 +110,13 @@ FOO: foo
   it('shows a failed release info', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-      .get('/apps/myapp/releases/10')
-      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
-      .reply(200, {
+      .reply(200, [{
         description: 'something changed',
         status: 'failed',
         user: { email: 'foo@foo.com' },
         created_at: d,
         version: 10
-      })
+      }])
       .get('/apps/myapp/releases/10/config-vars')
       .matchHeader('accept', 'application/vnd.heroku+json; version=3')
       .reply(200, configVars)
@@ -146,17 +137,14 @@ FOO: foo
   it('shows a pending release info', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-      .get('/apps/myapp/releases/10')
-      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
-      .reply(200, {
+      .reply(200, [{
         addon_plan_names: ['addon1', 'addon2'],
         description: 'something changed',
         status: 'pending',
         user: {email: 'foo@foo.com'},
         version: 10,
         created_at: d
-      })
+      }])
       .get('/apps/myapp/releases/10/config-vars')
       .matchHeader('accept', 'application/vnd.heroku+json; version=3')
       .reply(200, configVars)

--- a/test/commands/releases/output.js
+++ b/test/commands/releases/output.js
@@ -1,0 +1,52 @@
+'use strict'
+/* globals describe it beforeEach */
+
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const cmd = require('../../..').commands.find(c => c.topic === 'releases' && c.command === 'output')
+const expect = require('chai').expect
+
+describe('releases:output', function () {
+  beforeEach(() => cli.mockConsole())
+
+  it('warns if there is no output available', function () {
+    process.stdout.columns = 80
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/myapp/releases/10')
+      .reply(200, { 'version': 40 })
+    return cmd.run({app: 'myapp', args: {release: 'v10'}})
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(cli.stderr).to.equal(' ▸    Release v40 has no release output available.\n'))
+      .then(() => api.done())
+  })
+
+  it('shows the output from a specific release', function () {
+    process.stdout.columns = 80
+    let busl = nock('https://busl.test:443')
+      .get('/streams/release.log')
+      .reply(200, 'Release Output Content')
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/myapp/releases/10')
+      .reply(200, { 'version': 40, output_stream_url: 'https://busl.test/streams/release.log' })
+    return cmd.run({app: 'myapp', args: {release: 'v10'}})
+      .then(() => expect(cli.stdout).to.equal('Release Output Content\n'))
+      .then(() => expect(cli.stderr).to.equal(''))
+      .then(() => busl.done())
+      .then(() => api.done())
+  })
+
+  it('shows the output from the latest release', function () {
+    process.stdout.columns = 80
+    let busl = nock('https://busl.test:443')
+      .get('/streams/release.log')
+      .reply(200, 'Release Output Content')
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/myapp/releases')
+      .reply(200, [{ 'version': 40, output_stream_url: 'https://busl.test/streams/release.log' }])
+    return cmd.run({app: 'myapp', args: {}})
+      .then(() => expect(cli.stdout).to.equal('Release Output Content\n'))
+      .then(() => expect(cli.stderr).to.equal(''))
+      .then(() => busl.done())
+      .then(() => api.done())
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,7 +1798,7 @@ lodash.zip@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
 
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.2:
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2619,6 +2619,12 @@ standard@8.6.0:
     eslint-plugin-react "~6.7.1"
     eslint-plugin-standard "~2.0.1"
     standard-engine "~5.2.0"
+
+std-mocks@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/std-mocks/-/std-mocks-1.0.1.tgz#d3388876d7beeba3c70fbd8e2bcaf46eb07d79fe"
+  dependencies:
+    lodash "^4.11.1"
 
 strftime@0.10.0:
   version "0.10.0"


### PR DESCRIPTION
This command looks for the availability of an `output_stream_url` field, which will be a busl stream, and fetchs the log data from there.

cc @jbyrum @heroku/devex 