### PR TITLE
Use pipe to process.stdout instead of cli.log & refactor into finder

### DIFF
--- a/commands/releases/info.js
+++ b/commands/releases/info.js
@@ -8,52 +8,40 @@ function * run (context, heroku) {
   const shellescape = require('shell-escape')
   const statusHelper = require('./status_helper')
   const forEach = require('lodash.foreach')
-  let id = (context.args.release || 'current').toLowerCase()
-  id = id.startsWith('v') ? id.slice(1) : id
-  if (id === 'current') {
-    let release = yield releases.FindRelease(heroku, context.app, (releases) => releases[0])
-    id = release.version
-  }
 
-  let data = yield {
-    release: heroku.request({
-      path: `/apps/${context.app}/releases/${id}`,
-      headers: {
-        Accept: 'application/vnd.heroku+json; version=3'
-      }
-    }),
-    config: heroku.request({
-      path: `/apps/${context.app}/releases/${id}/config-vars`,
-      headers: {
-        Accept: 'application/vnd.heroku+json; version=3'
-      }
-    })
-  }
+  let release = yield releases.FindByLatestOrId(heroku, context.app, context.args.release)
+
+  let config = yield heroku.request({
+    path: `/apps/${context.app}/releases/${release.version}/config-vars`,
+    headers: {
+      Accept: 'application/vnd.heroku+json; version=3'
+    }
+  })
 
   if (context.flags.json) {
-    cli.styledJSON(data.release)
+    cli.styledJSON(release)
   } else {
-    let releaseChange = data.release.description
-    let status = statusHelper.description(data.release)
-    let statusColor = statusHelper.color(data.release.status)
+    let releaseChange = release.description
+    let status = statusHelper.description(release)
+    let statusColor = statusHelper.color(release.status)
     if (status !== undefined) {
       releaseChange += ' (' + cli.color[statusColor](status) + ')'
     }
 
-    cli.styledHeader(`Release ${cli.color.cyan('v' + data.release.version)}`)
+    cli.styledHeader(`Release ${cli.color.cyan('v' + release.version)}`)
     cli.styledObject({
-      'Add-ons': data.release.addon_plan_names,
+      'Add-ons': release.addon_plan_names,
       Change: releaseChange,
-      By: data.release.user.email,
-      When: data.release.created_at
+      By: release.user.email,
+      When: release.created_at
     })
 
     cli.log()
-    cli.styledHeader(`${cli.color.cyan('v' + data.release.version)} Config vars`)
+    cli.styledHeader(`${cli.color.cyan('v' + release.version)} Config vars`)
     if (context.flags.shell) {
-      forEach(data.config, (v, k) => cli.log(`${k}=${shellescape([v])}`))
+      forEach(config, (v, k) => cli.log(`${k}=${shellescape([v])}`))
     } else {
-      cli.styledObject(data.config)
+      cli.styledObject(config)
     }
   }
 }

--- a/commands/releases/output.js
+++ b/commands/releases/output.js
@@ -21,12 +21,11 @@ function * run (context, heroku) {
   }
 
   yield new Promise(function (resolve, reject) {
-    cli.got.stream(streamUrl)
-      .on('error', reject)
-      .on('end', resolve)
-      .on('data', function (c) {
-        cli.log(c.toString('utf8'))
-      })
+    let stream = cli.got.stream(streamUrl)
+    stream.on('error', reject)
+    stream.on('end', resolve)
+    let piped = stream.pipe(process.stdout)
+    piped.on('error', reject)
   })
 }
 

--- a/commands/releases/output.js
+++ b/commands/releases/output.js
@@ -5,14 +5,8 @@ let co = require('co')
 let releases = require('../../lib/releases')
 
 function * run (context, heroku) {
-  let release
-  if (context.args.release) {
-    let id = context.args.release.toLowerCase()
-    id = id.startsWith('v') ? id.slice(1) : id
-    release = yield heroku.get(`/apps/${context.app}/releases/${id}`)
-  } else {
-    release = yield releases.FindRelease(heroku, context.app, (releases) => releases[0])
-  }
+  let release = yield releases.FindByLatestOrId(heroku, context.app, context.args.release)
+
   let streamUrl = release.output_stream_url
 
   if (!streamUrl) {

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -1,11 +1,24 @@
 'use strict'
 
-module.exports = {
-  FindRelease: function (heroku, app, search) {
-    return heroku.request({
-      path: `/apps/${app}/releases`,
-      partial: true,
-      headers: { 'Range': 'version ..; max=10, order=desc' }
-    }).then(search)
+let FindRelease = function (heroku, app, search) {
+  return heroku.request({
+    path: `/apps/${app}/releases`,
+    partial: true,
+    headers: { 'Range': 'version ..; max=10, order=desc' }
+  }).then(search)
+}
+
+let FindByLatestOrId = function (heroku, app, release) {
+  let id = (release || 'current').toLowerCase()
+  id = id.startsWith('v') ? id.slice(1) : id
+  if (id === 'current') {
+    return FindRelease(heroku, app, (releases) => releases[0])
+  } else {
+    return heroku.get(`/apps/${app}/releases/${id}`)
   }
+}
+
+module.exports = {
+  FindRelease,
+  FindByLatestOrId
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "proxyquire": "1.7.11",
     "rimraf": "2.5.4",
     "standard": "8.6.0",
+    "std-mocks": "1.0.1",
     "testdouble": "2.0.1",
     "time-require": "0.1.2",
     "unexpected": "10.25.0"

--- a/test/commands/releases/info.js
+++ b/test/commands/releases/info.js
@@ -26,10 +26,7 @@ describe('releases:info', function () {
   it('shows most recent release info', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-      .get('/apps/myapp/releases/10')
-      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
-      .reply(200, release)
+      .reply(200, [release])
       .get('/apps/myapp/releases/10/config-vars')
       .matchHeader('accept', 'application/vnd.heroku+json; version=3')
       .reply(200, configVars)
@@ -52,10 +49,7 @@ FOO: foo
   it('shows most recent release info config vars as shell', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-      .get('/apps/myapp/releases/10')
-      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
-      .reply(200, release)
+      .reply(200, [release])
       .get('/apps/myapp/releases/10/config-vars')
       .matchHeader('accept', 'application/vnd.heroku+json; version=3')
       .reply(200, configVars)
@@ -116,16 +110,13 @@ FOO: foo
   it('shows a failed release info', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-      .get('/apps/myapp/releases/10')
-      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
-      .reply(200, {
+      .reply(200, [{
         description: 'something changed',
         status: 'failed',
         user: { email: 'foo@foo.com' },
         created_at: d,
         version: 10
-      })
+      }])
       .get('/apps/myapp/releases/10/config-vars')
       .matchHeader('accept', 'application/vnd.heroku+json; version=3')
       .reply(200, configVars)
@@ -146,17 +137,14 @@ FOO: foo
   it('shows a pending release info', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-      .get('/apps/myapp/releases/10')
-      .matchHeader('accept', 'application/vnd.heroku+json; version=3')
-      .reply(200, {
+      .reply(200, [{
         addon_plan_names: ['addon1', 'addon2'],
         description: 'something changed',
         status: 'pending',
         user: {email: 'foo@foo.com'},
         version: 10,
         created_at: d
-      })
+      }])
       .get('/apps/myapp/releases/10/config-vars')
       .matchHeader('accept', 'application/vnd.heroku+json; version=3')
       .reply(200, configVars)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,7 +1798,7 @@ lodash.zip@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
 
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.2:
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2619,6 +2619,12 @@ standard@8.6.0:
     eslint-plugin-react "~6.7.1"
     eslint-plugin-standard "~2.0.1"
     standard-engine "~5.2.0"
+
+std-mocks@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/std-mocks/-/std-mocks-1.0.1.tgz#d3388876d7beeba3c70fbd8e2bcaf46eb07d79fe"
+  dependencies:
+    lodash "^4.11.1"
 
 strftime@0.10.0:
   version "0.10.0"


### PR DESCRIPTION
@dmathieu I used `pipe` and `std-mocks` to stream the output.  I also did the refactor that I described in the original PR so that `info` and `output` treat the `release` arg the same.