### PR TITLE
Change favorites commands to match new longboard API

### DIFF
--- a/commands/apps/favorites/add.js
+++ b/commands/apps/favorites/add.js
@@ -7,13 +7,13 @@ function * run (context, heroku) {
   let app = context.app
 
   yield cli.action(`Adding ${cli.color.app(app)} to favorites`, co(function * () {
-    let favorites = yield heroku.request({host: 'longboard.heroku.com', path: '/favorites', headers: {Range: ''}})
-    if (favorites.find((f) => f.app_name === app)) throw new Error(`${cli.color.app(app)} is already a favorite app.`)
+    let favorites = yield heroku.request({host: 'longboard.heroku.com', path: '/favorites?type=app', headers: {Range: ''}})
+    if (favorites.find((f) => f.resource_name === app)) throw new Error(`${cli.color.app(app)} is already a favorite app.`)
     yield heroku.request({
       host: 'longboard.heroku.com',
       path: '/favorites',
       method: 'POST',
-      body: {app_id: app}
+      body: {type: 'app', resource_id: app}
     })
   }))
 }

--- a/commands/apps/favorites/index.js
+++ b/commands/apps/favorites/index.js
@@ -4,13 +4,13 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 
 function * run (context, heroku) {
-  let favorites = yield heroku.request({host: 'longboard.heroku.com', path: '/favorites', headers: {Range: ''}})
+  let favorites = yield heroku.request({host: 'longboard.heroku.com', path: '/favorites?type=app', headers: {Range: ''}})
 
   if (context.flags.json) {
     cli.styledJSON(favorites)
   } else {
     cli.styledHeader('Favorited Apps')
-    for (let f of favorites) cli.log(f.app_name)
+    for (let f of favorites) cli.log(f.resource_name)
   }
 }
 

--- a/commands/apps/favorites/remove.js
+++ b/commands/apps/favorites/remove.js
@@ -7,11 +7,12 @@ function * run (context, heroku) {
   let app = context.app
 
   yield cli.action(`Removing ${cli.color.app(app)} from favorites`, co(function * () {
-    let favorites = yield heroku.request({host: 'longboard.heroku.com', path: '/favorites', headers: {Range: ''}})
-    if (!favorites.find((f) => f.app_name === app)) throw new Error(`${cli.color.app(app)} is not already a favorite app.`)
+    let favorites = yield heroku.request({host: 'longboard.heroku.com', path: '/favorites?type=app', headers: {Range: ''}})
+    let favorite = favorites.find((f) => f.resource_name === app)
+    if (!favorite) throw new Error(`${cli.color.app(app)} is not already a favorite app.`)
     yield heroku.request({
       host: 'longboard.heroku.com',
-      path: `/favorites/${app}`,
+      path: `/favorites/${favorite.id}`,
       method: 'DELETE'
     })
   }))

--- a/test/commands/apps/favorites/add.js
+++ b/test/commands/apps/favorites/add.js
@@ -11,9 +11,9 @@ describe('apps:favorites:add', () => {
 
   it('adds the app as a favorite', () => {
     let api = nock('https://longboard.heroku.com:443')
-      .get('/favorites')
+      .get('/favorites?type=app')
       .reply(200, [])
-      .post('/favorites', {app_id: 'myapp'})
+      .post('/favorites', {resource_id: 'myapp'})
       .reply(201)
 
     return cmd.run({app: 'myapp'})

--- a/test/commands/apps/favorites/index.js
+++ b/test/commands/apps/favorites/index.js
@@ -12,8 +12,8 @@ describe('apps:favorites:remove', () => {
 
   it('shows all favorite apps', () => {
     let api = nock('https://longboard.heroku.com:443')
-      .get('/favorites')
-      .reply(200, [{app_name: 'myapp'}, {app_name: 'myotherapp'}])
+      .get('/favorites?type=app')
+      .reply(200, [{resource_name: 'myapp'}, {resource_name: 'myotherapp'}])
 
     return cmd.run({app: 'myapp', flags: {json: false}})
       .then(() => expect(cli.stdout).to.equal(`=== Favorited Apps
@@ -26,11 +26,11 @@ myotherapp
 
   it('shows all favorite apps as json', () => {
     let api = nock('https://longboard.heroku.com:443')
-      .get('/favorites')
-      .reply(200, [{app_name: 'myapp'}, {app_name: 'myotherapp'}])
+      .get('/favorites?type=app')
+      .reply(200, [{resource_name: 'myapp'}, {resource_name: 'myotherapp'}])
 
     return cmd.run({app: 'myapp', flags: {json: true}})
-      .then(() => expect(JSON.parse(cli.stdout)[0].app_name).to.equal('myapp'))
+      .then(() => expect(JSON.parse(cli.stdout)[0].resource_name).to.equal('myapp'))
       .then(() => expect(cli.stderr).to.equal(''))
       .then(() => api.done())
   })

--- a/test/commands/apps/favorites/remove.js
+++ b/test/commands/apps/favorites/remove.js
@@ -11,9 +11,9 @@ describe('apps:favorites:remove', () => {
 
   it('removes the app as a favorite', () => {
     let api = nock('https://longboard.heroku.com:443')
-      .get('/favorites')
-      .reply(200, [{app_name: 'myapp'}])
-      .delete('/favorites/myapp')
+      .get('/favorites?type=app')
+      .reply(200, [{id: 'favoriteid', resource_name: 'myapp'}])
+      .delete('/favorites/favoriteid')
       .reply(201)
 
     return cmd.run({app: 'myapp'})


### PR DESCRIPTION
We're currently working on letting users favorite other resources in addition to apps. Since the favorites API was very app-specific, we recently released a backwards-compatible update to longboard that will allow it to work with other resources. This PR updates the CLI to work with the new API format.

Please let me know if you have any questions or concerns about these changes. Thanks!