### PR TITLE
Display a message telling to retry in case of release output 404

### DIFF
--- a/commands/releases/output.js
+++ b/commands/releases/output.js
@@ -16,6 +16,13 @@ function * run (context, heroku) {
   }
 
   yield output.Stream(streamUrl)
+    .catch(err => {
+      if (err.statusCode === 404) {
+        cli.warn('Release command not started yet. Please try again in a few seconds.')
+        return
+      }
+      throw err
+    })
 }
 
 module.exports = {

--- a/commands/releases/rollback.js
+++ b/commands/releases/rollback.js
@@ -27,6 +27,13 @@ To undo, run: ${cli.color.cmd('heroku rollback v' + (latest.version - 1))}`)
   if (latest.output_stream_url) {
     cli.log('Running release command...')
     yield output.Stream(release.output_stream_url)
+      .catch(err => {
+        if (err.statusCode === 404) {
+          cli.warn('Release command starting. Use `heroku releases:output` to view the log.')
+          return
+        }
+        throw err
+      })
   }
 }
 


### PR DESCRIPTION
It can take a few seconds to create the release output stream. During that time, calling it will return a 404.

Send a nicer error message if that happens, until we can properly retry. See #174.