### PR TITLE
Fix docstring for auth:logout

### DIFF
--- a/src/commands/auth/logout.js
+++ b/src/commands/auth/logout.js
@@ -11,7 +11,7 @@ function * run (context, heroku) {
 }
 
 const cmd = {
-  description: 'display the current logged in user',
+  description: 'Logout of you current CLI session',
   run: cli.command(co.wrap(run))
 }
 


### PR DESCRIPTION
Previous docstring was a dup of auth:whoami, causing some confusion for
customers.