### PR TITLE
Use heroku-cli-util.logout to get auth clearing

### DIFF
--- a/src/commands/auth/logout.js
+++ b/src/commands/auth/logout.js
@@ -2,11 +2,7 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 
 function * run (context, heroku) {
-  const Netrc = require('netrc-parser')
-  const netrc = new Netrc()
-  delete netrc.machines['api.heroku.com']
-  delete netrc.machines['git.heroku.com']
-  netrc.save()
+  yield cli.logout()
   cli.log('Local credentials cleared')
 }
 

--- a/test/commands/auth/logout.js
+++ b/test/commands/auth/logout.js
@@ -2,27 +2,25 @@
 /* globals describe beforeEach it */
 
 const cli = require('heroku-cli-util')
-const proxyquire = require('proxyquire')
-const td = require('testdouble')
 
-let netrcMock = td.constructor(require('netrc-parser'))
+const proxyquire = require('proxyquire')
+
+// budget mock since testdouble does not support generators
+const cliMock = function * () {
+  cliMock.called = true
+}
+
 // get command from index.js
-const cmd = proxyquire('../../../src/commands/auth/logout', {'netrc-parser': netrcMock})[0]
+const cmd = proxyquire('../../../src/commands/auth/logout', {'heroku-cli-util': {logout: cliMock}})[0]
 const expect = require('unexpected')
 
 describe('auth:logout', () => {
   beforeEach(() => cli.mockConsole())
 
   it('logs out the user', () => {
-    let machines = {
-      'api.heroku.com': { login: 'u', password: 'p' },
-      'git.heroku.com': { login: 'u', password: 'p' }
-    }
-    netrcMock.prototype.machines = machines
     return cmd.run({})
       .then(() => {
-        td.verify(netrcMock.prototype.save())
-        expect(machines, 'to equal', {})
+        expect(cliMock.called, 'to be true')
         expect(cli.stderr, 'to be empty')
         expect(cli.stdout, 'to equal', 'Local credentials cleared\n')
       })


### PR DESCRIPTION
@dickeyxxx could you review?  this is to fix https://github.com/heroku/prodsec/issues/1