### PR TITLE
shield: stop converting Private-* dynos to Shield-* dynos

### DIFF
--- a/src/commands/ps/index.js
+++ b/src/commands/ps/index.js
@@ -122,13 +122,6 @@ function * run (context, heroku) {
   promises.account_info = heroku.request({path: '/account'})
 
   let {dynos, app_info, account_info} = yield promises
-  const shielded = app_info.space && app_info.space.shield
-
-  if (shielded) {
-    dynos.forEach(d => {
-      d.size = d.size.replace('Private-', 'Shield-')
-    })
-  }
 
   if (types.length > 0) {
     dynos = dynos.filter(dyno => types.find(t => dyno.type === t))

--- a/src/commands/ps/scale.js
+++ b/src/commands/ps/scale.js
@@ -18,7 +18,6 @@ function * run (context, heroku) {
       let change = arg.match(/^([\w-]+)([=+-]\d+)(?::([\w-]+))?$/)
       if (!change) return
       let quantity = change[2][0] === '=' ? change[2].substr(1) : change[2]
-      if (change[3]) change[3] = change[3].replace('Shield-', 'Private-')
       return {type: change[1], quantity, size: change[3]}
     }))
   }
@@ -27,26 +26,12 @@ function * run (context, heroku) {
   if (changes.length === 0) {
     let formation = yield heroku.get(`/apps/${app}/formation`)
 
-    const appProps = yield heroku.get(`/apps/${app}`)
-    const shielded = appProps.space && appProps.space.shield
-    if (shielded) {
-      formation.forEach((d) => {
-        d.size = d.size.replace('Private-', 'Shield-')
-      })
-    }
-
     if (formation.length === 0) throw emptyFormationErr(app)
     cli.log(formation.map((d) => `${d.type}=${d.quantity}:${d.size}`).sort().join(' '))
   } else {
     yield cli.action('Scaling dynos', {success: false}, co(function * () {
       let formation = yield heroku.request({method: 'PATCH', path: `/apps/${app}/formation`, body: {updates: changes}})
-      const appProps = yield heroku.get(`/apps/${app}`)
-      const shielded = appProps.space && appProps.space.shield
-      if (shielded) {
-        formation.forEach((d) => {
-          d.size = d.size.replace('Private-', 'Shield-')
-        })
-      }
+
       let output = formation.filter((f) => changes.find((c) => c.type === f.type))
         .map((d) => `${cli.color.green(d.type)} at ${d.quantity}:${d.size}`)
       cli.action.done(`done, now running ${output.join(', ')}`)

--- a/src/commands/ps/type.js
+++ b/src/commands/ps/type.js
@@ -38,15 +38,8 @@ Types: ${cli.color.yellow(formation.map((f) => f.type).join(', '))}`)
 
   let displayFormation = co.wrap(function * () {
     let formation = yield heroku.get(`/apps/${app}/formation`)
-    const appProps = yield heroku.get(`/apps/${app}`)
-    const shielded = appProps.space && appProps.space.shield
 
     formation = sortBy(formation, 'type')
-    if (shielded) {
-      formation.forEach((d) => {
-        d.size = d.size.replace('Private-', 'Shield-')
-      })
-    }
 
     formation = formation.map((d) => ({
       type: cli.color.green(d.type),

--- a/test/commands/ps/index.js
+++ b/test/commands/ps/index.js
@@ -82,8 +82,8 @@ run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
       .reply(200, {space: {shield: true}})
       .get('/apps/myapp/dynos')
       .reply(200, [
-        {command: 'npm start', size: 'Private-M', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up'},
-        {command: 'bash', size: 'Private-L', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up'}
+        {command: 'npm start', size: 'Shield-M', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up'},
+        {command: 'bash', size: 'Shield-L', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up'}
       ])
 
     stubAppAndAccount()
@@ -160,8 +160,8 @@ run.1 (Shield-L): up ${hourAgoStr} (~ 1h ago): bash
       .reply(200, {space: {shield: true}})
       .get('/apps/myapp/dynos?extended=true')
       .reply(200, [
-        {id: 100, command: 'npm start', size: 'Private-M', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.1', port: 8000, az: 'us-east', route: 'da route' }},
-        {id: 101, command: 'bash', size: 'Private-L', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.2', port: 8000, az: 'us-east', route: 'da route' }}
+        {id: 100, command: 'npm start', size: 'Shield-M', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.1', port: 8000, az: 'us-east', route: 'da route' }},
+        {id: 101, command: 'bash', size: 'Shield-L', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.2', port: 8000, az: 'us-east', route: 'da route' }}
       ])
 
     return cmd.run({app: 'myapp', args: [], flags: {extended: true}})

--- a/test/commands/ps/scale.js
+++ b/test/commands/ps/scale.js
@@ -15,8 +15,6 @@ describe('ps:scale', () => {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp/formation')
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
-      .get('/apps/myapp')
-      .reply(200, {name: 'myapp'})
 
     return cmd.run({app: 'myapp', args: []})
       .then(() => expect(cli.stdout, 'to equal', 'web=1:Free worker=2:Free\n'))
@@ -27,9 +25,7 @@ describe('ps:scale', () => {
   it('shows formation with shield dynos for apps in a shielded private space', () => {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp/formation')
-      .reply(200, [{type: 'web', quantity: 1, size: 'Private-L'}, {type: 'worker', quantity: 2, size: 'Private-M'}])
-      .get('/apps/myapp')
-      .reply(200, {name: 'myapp', space: {shield: true}})
+      .reply(200, [{type: 'web', quantity: 1, size: 'Shield-L'}, {type: 'worker', quantity: 2, size: 'Shield-M'}])
 
     return cmd.run({app: 'myapp', args: []})
       .then(() => expect(cli.stdout, 'to equal', 'web=1:Shield-L worker=2:Shield-M\n'))
@@ -41,8 +37,6 @@ describe('ps:scale', () => {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp/formation')
       .reply(200, [])
-      .get('/apps/myapp')
-      .reply(200, {name: 'myapp'})
 
     return expect(cmd.run({app: 'myapp', args: []}),
       'to be rejected with', {message: /^No process types on myapp./})
@@ -55,8 +49,6 @@ describe('ps:scale', () => {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp/formation', {updates: [{type: 'web', quantity: '1'}, {type: 'worker', quantity: '2'}]})
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
-      .get('/apps/myapp')
-      .reply(200, {name: 'myapp'})
 
     return cmd.run({app: 'myapp', args: ['web=1', 'worker=2']})
       .then(() => expect(cli.stdout, 'to be empty'))
@@ -66,10 +58,8 @@ describe('ps:scale', () => {
 
   it('scales up a shield dyno if the app is in a shielded private space', () => {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/myapp/formation', {updates: [{type: 'web', quantity: '1', size: 'Private-L'}]})
-      .reply(200, [{type: 'web', quantity: 1, size: 'Private-L'}])
-      .get('/apps/myapp')
-      .reply(200, {name: 'myapp', space: {shield: true}})
+      .patch('/apps/myapp/formation', {updates: [{type: 'web', quantity: '1', size: 'Shield-L'}]})
+      .reply(200, [{type: 'web', quantity: 1, size: 'Shield-L'}])
 
     return cmd.run({app: 'myapp', args: ['web=1:Shield-L']})
       .then(() => expect(cli.stdout, 'to be empty'))
@@ -81,8 +71,6 @@ describe('ps:scale', () => {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp/formation', {updates: [{type: 'web', quantity: '+1'}]})
       .reply(200, [{type: 'web', quantity: 2, size: 'Free'}])
-      .get('/apps/myapp')
-      .reply(200, {name: 'myapp'})
 
     return cmd.run({app: 'myapp', args: ['web+1']})
       .then(() => expect(cli.stdout, 'to be empty'))

--- a/test/commands/ps/type.js
+++ b/test/commands/ps/type.js
@@ -6,11 +6,6 @@ const cmd = commands.find((c) => c.topic === 'ps' && c.command === 'type')
 const nock = require('nock')
 const expect = require('chai').expect
 
-function app (args = {}) {
-  let base = {name: 'myapp'}
-  return Object.assign(base, args)
-}
-
 describe('ps:type', function () {
   beforeEach(function () {
     cli.mockConsole()
@@ -19,8 +14,6 @@ describe('ps:type', function () {
 
   it('switches to hobby dynos', function () {
     let api = nock('https://api.heroku.com')
-      .get('/apps/myapp')
-      .reply(200, app())
       .get('/apps/myapp/formation')
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
       .patch('/apps/myapp/formation', {updates: [{type: 'web', size: 'hobby'}, {type: 'worker', size: 'hobby'}]})
@@ -40,8 +33,6 @@ worker  Hobby  2    14
 
   it('switches to standard-1x and standard-2x dynos', function () {
     let api = nock('https://api.heroku.com')
-      .get('/apps/myapp')
-      .reply(200, app())
       .get('/apps/myapp/formation')
       .reply(200, [{type: 'web', quantity: 1, size: 'Free'}, {type: 'worker', quantity: 2, size: 'Free'}])
       .patch('/apps/myapp/formation', {updates: [{type: 'web', size: 'standard-1x'}, {type: 'worker', size: 'standard-2x'}]})
@@ -61,10 +52,8 @@ worker  Standard-2X  2    100
 
   it('displays Shield dynos for apps in shielded spaces', function () {
     let api = nock('https://api.heroku.com')
-      .get('/apps/myapp')
-      .reply(200, app({space: {shield: true}}))
       .get('/apps/myapp/formation')
-      .reply(200, [{type: 'web', quantity: 0, size: 'Private-M'}, {type: 'web', quantity: 0, size: 'Private-L'}])
+      .reply(200, [{type: 'web', quantity: 0, size: 'Shield-M'}, {type: 'web', quantity: 0, size: 'Shield-L'}])
 
     return cmd.run({app: 'myapp', args: []})
       .then(() => expect(cli.stdout).to.eq(`type  size      qty  cost/mo


### PR DESCRIPTION
This stops the cosmetic change of Private-* dynos to Shield-* dynos for
Shield Private Spaces. When Api begins sending the actual Shield dyno
types then this cosmetic switcheroo will no longer be necessary.