### PR TITLE
Make release pending wording consistent

### DIFF
--- a/src/status_helper.js
+++ b/src/status_helper.js
@@ -1,23 +1,9 @@
 'use strict'
 
-function pendingDescription (release, runningRelease, runningSlug) {
-  if (runningRelease && runningRelease.id === release.id && hasReleasePhase(runningSlug)) {
-    return 'release command executing'
-  } else {
-    return 'pending'
-  }
-}
-
-function hasReleasePhase (slug) {
-  return slug &&
-    slug.process_types &&
-    slug.process_types.release
-}
-
-module.exports.description = function (release, runningRelease, runningSlug) {
+module.exports.description = function (release) {
   switch (release.status) {
     case 'pending':
-      return pendingDescription(release, runningRelease, runningSlug)
+      return 'release command executing'
     case 'failed':
       return 'release command failed'
     default:

--- a/test/commands/releases/index.js
+++ b/test/commands/releases/index.js
@@ -146,7 +146,7 @@ describe('releases', () => {
       .reply(200, slug)
     return cmd.run({app: 'myapp', flags: {}})
       .then(() => expect(cli.stdout, 'to equal', `=== myapp Releases - Current: v37
-v41  third commit pending         jeff@heroku.com  2015/11/18 01:36:38 +0000
+v41  … release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars          jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  … release command failed     jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  … release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
@@ -165,11 +165,11 @@ v37  first commit                 jeff@heroku.com  2015/11/18 01:36:38 +0000
       .reply(200, {})
     return cmd.run({app: 'myapp', flags: {}})
       .then(() => expect(cli.stdout, 'to equal', `=== myapp Releases - Current: v37
-v41  third commit pending      jeff@heroku.com  2015/11/18 01:36:38 +0000
-v40  Set foo config vars       jeff@heroku.com  2015/11/18 01:37:41 +0000
-v39  … release command failed  jeff@heroku.com  2015/11/18 01:36:38 +0000
-v38  second commit pending     jeff@heroku.com  2015/11/18 01:36:38 +0000
-v37  first commit              jeff@heroku.com  2015/11/18 01:36:38 +0000
+v41  … release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
+v40  Set foo config vars          jeff@heroku.com  2015/11/18 01:37:41 +0000
+v39  … release command failed     jeff@heroku.com  2015/11/18 01:36:38 +0000
+v38  … release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
+v37  first commit                 jeff@heroku.com  2015/11/18 01:36:38 +0000
 `))
       .then(() => expect(cli.stderr, 'to be empty'))
       .then(() => api.done())
@@ -182,7 +182,7 @@ v37  first commit              jeff@heroku.com  2015/11/18 01:36:38 +0000
       .reply(200, releasesNoSlug)
     return cmd.run({app: 'myapp', flags: {}})
       .then(() => expect(cli.stdout, 'to equal', `=== myapp Releases
-v1  first commit pending  jeff@heroku.com  2015/11/18 01:36:38 +0000
+v1  … release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 `))
       .then(() => expect(cli.stderr, 'to be empty'))
       .then(() => api.done())
@@ -233,7 +233,7 @@ v40      Set foo config vars   jeff@heroku.com  2015/11/18 01:37:41 +0000  1    
       .reply(200, slug)
     return cmd.run({app: 'myapp', flags: {}})
       .then(() => expect(cli.stdout, 'to equal', `=== myapp Releases
-v41  third commit pending         jeff@heroku.com  2015/11/18 01:36:38 +0000
+v41  … release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars          jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  … release command failed     jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  … release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000

--- a/test/commands/releases/info.js
+++ b/test/commands/releases/info.js
@@ -145,7 +145,7 @@ FOO: foo
 Add-ons: addon1
          addon2
 By:      foo@foo.com
-Change:  something changed (pending)
+Change:  something changed (release command executing)
 When:    ${d.toISOString()}
 
 === v10 Config vars


### PR DESCRIPTION
This was introduced to be consistent with releases not running concurrently.
That project never came to be though.

Closes #192