### PR TITLE
Add a `--manifest` option for beta users to support heroku.yml files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "filesize": "^3.5.11",
     "heroku-cli-util": "^8.0.6",
     "inquirer": "^5.2.0",
+    "js-yaml": "^3.9.1",
     "lodash": "^4.17.10",
     "lodash.compact": "^3.0.1",
     "lodash.countby": "^4.6.0",

--- a/src/commands/apps/create.js
+++ b/src/commands/apps/create.js
@@ -2,44 +2,62 @@
 
 let co = require('co')
 let cli = require('heroku-cli-util')
+const {safeLoad} = require('js-yaml')
+const {readFile} = require('fs-extra')
 const {flags} = require('@heroku-cli/command')
 const {BuildpackCompletion, RegionCompletion, RemoteCompletion, SpaceCompletion, StackCompletion} = require('@heroku-cli/command/lib/completions')
 
-function * run (context, heroku) {
-  let git = require('../../git')(context)
-  let name = context.flags.app || context.args.app || process.env.HEROKU_APP
+function createText (name, space) {
+  let text = `Creating ${name ? cli.color.app(name) : 'app'}`
+  if (space) {
+    text += ` in space ${space}`
+  }
+  return text
+}
 
-  function createApp () {
-    let params = {
-      name,
-      organization: context.org || context.team || context.flags.team,
-      region: context.flags.region,
-      space: context.flags.space,
-      stack: context.flags.stack,
-      kernel: context.flags.kernel,
-      locked: context.flags.locked
-    }
-
-    return heroku.request({
-      method: 'POST',
-      path: (params.space || params.organization) ? '/organizations/apps' : '/apps',
-      body: params
-    }).then(app => {
-      let status = name ? 'done' : `done, ${cli.color.app(app.name)}`
-      if (context.flags.region) status += `, region is ${cli.color.yellow(app.region.name)}`
-      if (context.flags.stack) status += `, stack is ${cli.color.yellow(app.stack.name)}`
-      cli.action.done(status)
-      return app
-    })
+function createApp (context, heroku, name, stack) {
+  let params = {
+    name,
+    organization: context.org || context.team || context.flags.team,
+    region: context.flags.region,
+    space: context.flags.space,
+    stack,
+    kernel: context.flags.kernel,
+    locked: context.flags.locked
   }
 
-  let addAddons = co.wrap(function * (app, addons) {
-    for (let addon of addons) {
-      addon = addon.trim()
-      let request = heroku.post(`/apps/${app.name}/addons`, {body: {plan: addon}})
-      yield cli.action(`Adding ${cli.color.green(addon)}`, request)
-    }
+  return heroku.request({
+    method: 'POST',
+    path: (params.space || params.organization) ? '/organizations/apps' : '/apps',
+    body: params
+  }).then(app => {
+    let status = name ? 'done' : `done, ${cli.color.app(app.name)}`
+    if (context.flags.region) status += `, region is ${cli.color.yellow(app.region.name)}`
+    if (stack) status += `, stack is ${cli.color.yellow(app.stack.name)}`
+    cli.action.done(status)
+    return app
   })
+}
+
+const addAddons = co.wrap(function * addAddons (heroku, app, addons) {
+  for (let addon of addons) {
+    let body = {
+      plan: addon.plan,
+    }
+    if (addon.as) {
+      body.attachment = {
+        name: addon.as,
+      }
+    }
+
+    let request = heroku.post(`/apps/${app.name}/addons`, {body})
+    yield cli.action(`Adding ${cli.color.green(addon.plan)}`, request)
+  }
+})
+
+function * runFromFlags (context, heroku) {
+  let git = require('../../git')(context)
+  let name = context.flags.app || context.args.app || process.env.HEROKU_APP
 
   function addBuildpack (app, buildpack) {
     return cli.action(`Setting buildpack to ${cli.color.cyan(buildpack)}`, heroku.request({
@@ -50,17 +68,16 @@ function * run (context, heroku) {
     }))
   }
 
-  function createText (name, space) {
-    let text = `Creating ${name ? cli.color.app(name) : 'app'}`
-    if (space) {
-      text += ` in space ${space}`
-    }
-    return text
+  let app = yield cli.action(
+      createText(name, context.flags.space), {success: false}, createApp(context, heroku, name, context.flags.stack))
+
+  if (context.flags.addons) {
+    let plans = context.flags.addons.split(',')
+    let addons = plans.map(plan => ({
+      plan: plan.trim(),
+    }))
+    yield addAddons(heroku, app, context.flags.addons.split(','))
   }
-
-  let app = yield cli.action(createText(name, context.flags.space), {success: false}, createApp())
-
-  if (context.flags.addons) yield addAddons(app, context.flags.addons.split(','))
   if (context.flags.buildpack) yield addBuildpack(app, context.flags.buildpack)
 
   let remoteUrl = context.flags['ssh-git'] ? git.sshGitUrl(app.name) : git.gitUrl(app.name)
@@ -70,6 +87,32 @@ function * run (context, heroku) {
   } else {
     cli.log(`${cli.color.cyan(app.web_url)} | ${cli.color.green(remoteUrl)}`)
   }
+}
+
+const readManifest = co.wrap(function * readManifest() {
+  let buffer = yield readFile('heroku.yml')
+  return safeLoad(buffer, {filename: 'heroku.yml'})
+})
+
+function * runFromManifest (context, heroku) {
+  let git = require('../../git')(context)
+  let name = context.flags.app || context.args.app || process.env.HEROKU_APP
+
+  let manifest = yield cli.action('Reading heroku.yml manifest', readManifest())
+
+  let app = yield cli.action(
+      createText(name, context.flags.space), {success: false}, createApp(context, heroku, name, 'container'))
+
+  let setup = manifest.setup || {}
+  let addons = setup.addons || []
+
+  yield addAddons(heroku, app, addons)
+}
+
+function run (context, heroku) {
+  if (context.flags.manifest)
+    return runFromManifest(context, heroku)
+  return runFromFlags(context, heroku)
 }
 
 let cmd = {
@@ -82,6 +125,9 @@ let cmd = {
 
     # or just
     $ heroku create
+
+    # use a heroku.yml manifest file
+    $ heroku apps:create --manifest
 
     # specify a buildpack
     $ heroku apps:create --buildpack https://github.com/some/buildpack.git
@@ -102,6 +148,7 @@ let cmd = {
     {name: 'app', char: 'a', hasValue: true, hidden: true},
     {name: 'addons', hasValue: true, description: 'comma-delimited list of addons to install'},
     {name: 'buildpack', char: 'b', hasValue: true, description: 'buildpack url to use for this app', completion: BuildpackCompletion},
+    {name: 'manifest', char: 'm', hasValue: false, description: 'use heroku.yml settings for this app'},
     {name: 'no-remote', char: 'n', description: 'do not create a git remote'},
     {name: 'remote', char: 'r', hasValue: true, description: 'the git remote to create, default "heroku"', completion: RemoteCompletion},
     {name: 'stack', char: 's', hasValue: true, description: 'the stack to create the app on', completion: StackCompletion},

--- a/src/commands/apps/create.js
+++ b/src/commands/apps/create.js
@@ -54,6 +54,12 @@ async function addAddons (heroku, app, addons) {
   }
 }
 
+function addonsFromPlans (plans) {
+  return plans.map(plan => ({
+    plan: plan.trim(),
+  }))
+}
+
 async function runFromFlags (context, heroku) {
   let git = require('../../git')(context)
   let name = context.flags.app || context.args.app || process.env.HEROKU_APP
@@ -68,14 +74,12 @@ async function runFromFlags (context, heroku) {
   }
 
   let app = await cli.action(
-      createText(name, context.flags.space), {success: false}, createApp(context, heroku, name, context.flags.stack))
+    createText(name, context.flags.space), {success: false}, createApp(context, heroku, name, context.flags.stack))
 
   if (context.flags.addons) {
     let plans = context.flags.addons.split(',')
-    let addons = plans.map(plan => ({
-      plan: plan.trim(),
-    }))
-      await addAddons(heroku, app, context.flags.addons.split(','))
+    let addons = addonsFromPlans(plans)
+    await addAddons(heroku, app, addons)
   }
   if (context.flags.buildpack) await addBuildpack(app, context.flags.buildpack)
 

--- a/src/commands/apps/create.js
+++ b/src/commands/apps/create.js
@@ -14,7 +14,7 @@ function createText (name, space) {
   return text
 }
 
-function createApp (context, heroku, name, stack) {
+async function createApp (context, heroku, name, stack) {
   let params = {
     name,
     organization: context.org || context.team || context.flags.team,
@@ -25,17 +25,17 @@ function createApp (context, heroku, name, stack) {
     locked: context.flags.locked
   }
 
-  return heroku.request({
+  let app = await heroku.request({
     method: 'POST',
     path: (params.space || params.organization) ? '/organizations/apps' : '/apps',
     body: params
-  }).then(app => {
-    let status = name ? 'done' : `done, ${cli.color.app(app.name)}`
-    if (context.flags.region) status += `, region is ${cli.color.yellow(app.region.name)}`
-    if (stack) status += `, stack is ${cli.color.yellow(app.stack.name)}`
-    cli.action.done(status)
-    return app
   })
+
+  let status = name ? 'done' : `done, ${cli.color.app(app.name)}`
+  if (context.flags.region) status += `, region is ${cli.color.yellow(app.region.name)}`
+  if (stack) status += `, stack is ${cli.color.yellow(app.stack.name)}`
+  cli.action.done(status)
+  return app
 }
 
 async function addAddons (heroku, app, addons) {

--- a/src/commands/apps/create.js
+++ b/src/commands/apps/create.js
@@ -113,8 +113,9 @@ async function runFromManifest (context, heroku) {
 }
 
 function run (context, heroku) {
-  if (context.flags.manifest)
-    return runFromManifest(context, heroku)
+  if (context.config.channel === 'beta')
+    if (context.flags.manifest)
+      return runFromManifest(context, heroku)
   return runFromFlags(context, heroku)
 }
 
@@ -151,7 +152,7 @@ let cmd = {
     {name: 'app', char: 'a', hasValue: true, hidden: true},
     {name: 'addons', hasValue: true, description: 'comma-delimited list of addons to install'},
     {name: 'buildpack', char: 'b', hasValue: true, description: 'buildpack url to use for this app', completion: BuildpackCompletion},
-    {name: 'manifest', char: 'm', hasValue: false, description: 'use heroku.yml settings for this app'},
+    {name: 'manifest', char: 'm', hasValue: false, description: 'use heroku.yml settings for this app', hidden: true},
     {name: 'no-remote', char: 'n', description: 'do not create a git remote'},
     {name: 'remote', char: 'r', hasValue: true, description: 'the git remote to create, default "heroku"', completion: RemoteCompletion},
     {name: 'stack', char: 's', hasValue: true, description: 'the stack to create the app on', completion: StackCompletion},

--- a/test/commands/apps/create.js
+++ b/test/commands/apps/create.js
@@ -22,7 +22,7 @@ describe('apps:create', function () {
         web_url: 'https://foobar.com'
       })
 
-    return apps.run({flags: {}, args: {}, httpGitHost: 'git.heroku.com'}).then(function () {
+    return apps.run({flags: {}, args: {}, httpGitHost: 'git.heroku.com', config: {channel: 'beta'}}).then(function () {
       mock.done()
       expect(cli.stderr).to.equal('Creating app... done, foobar\n')
       expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
@@ -40,7 +40,7 @@ describe('apps:create', function () {
         web_url: 'https://foobar.com'
       })
 
-    return apps.run({flags: {space: 'my-space-name'}, args: {}, httpGitHost: 'git.heroku.com'}).then(function () {
+    return apps.run({flags: {space: 'my-space-name'}, args: {}, httpGitHost: 'git.heroku.com', config: {channel: 'beta'}}).then(function () {
       mock.done()
       expect(cli.stderr).to.equal('Creating app in space my-space-name... done, foobar\n')
       expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
@@ -58,7 +58,7 @@ describe('apps:create', function () {
       })
       .reply(200, json)
 
-    return apps.run({flags: {json: true}, args: {}, httpGitHost: 'git.heroku.com'}).then(function () {
+    return apps.run({flags: {json: true}, args: {}, httpGitHost: 'git.heroku.com', config: {channel: 'beta'}}).then(function () {
       mock.done()
 
       expect(cli.stderr).to.equal('Creating app... done, foobar\n')


### PR DESCRIPTION
This implementation supports a single `setup` entry in the YAML file, for specifying addons. We will expand this to support the rest of the planned heroku.yml functionality in future pull requests.